### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gopher64/gopher64/security/code-scanning/4](https://github.com/gopher64/gopher64/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the `GITHUB_TOKEN` to `contents: read`. This is sufficient for the current workflow, as it primarily involves building and uploading artifacts, which do not require write permissions. The `permissions` block will be added at the top of the workflow, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
