### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Rust
 permissions:
   contents: read
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/gopher64/gopher64/security/code-scanning/3](https://github.com/gopher64/gopher64/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function. Based on the actions used in the workflow, the minimal permissions required are `contents: read`. This will ensure that the workflow can interact with the repository contents without granting unnecessary write access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to each job individually. In this case, adding it at the root level is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
