### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/gopher64/gopher64/security/code-scanning/1](https://github.com/gopher64/gopher64/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is sufficient for `actions/checkout@v4`.
- `contents: write` is required for `actions/upload-artifact@v4`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to each job individually. Since all jobs in this workflow perform similar tasks, adding the block at the root level is more efficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
