### PR TITLE
Remove custom linker for Linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,3 @@
-[target.'cfg(target_os = "linux")']
-rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
-
 [target.'cfg(target_os = "windows")']
 linker = "rust-lld"
 


### PR DESCRIPTION
I believe this should be possible as of Rust 1.90