### PR TITLE
Remove custom linker for Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,6 @@
 [target.'cfg(target_os = "linux")']
 rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
 
-[target.'cfg(target_os = "windows")']
-rustflags = ["-C", "linker=lld-link", "-C", "link-arg=-fuse-ld=lld-link"]
-
 [target.'cfg(target_arch = "x86_64")']
 rustflags = ["-C", "target-cpu=x86-64-v3"]
 


### PR DESCRIPTION
Putting this here so I can test with newer versions of Rust