### PR TITLE
re-add framebuffer tracking

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -117,6 +117,7 @@ fn main() {
         .allowlist_function("rdp_onscreen_message")
         .allowlist_function("rdp_check_callback")
         .allowlist_function("rdp_new_processor")
+        .allowlist_function("rdp_check_framebuffers")
         .allowlist_function("rdp_state_size")
         .allowlist_function("rdp_save_state")
         .allowlist_function("rdp_load_state")

--- a/parallel-rdp/interface.hpp
+++ b/parallel-rdp/interface.hpp
@@ -47,6 +47,7 @@ extern "C"
 	uint64_t rdp_process_commands();
 	void rdp_onscreen_message(const char *_message);
 	void rdp_new_processor(GFX_INFO _gfx_info);
+	void rdp_check_framebuffers(uint32_t address, uint32_t length);
 	size_t rdp_state_size();
 	void rdp_save_state(uint8_t *state);
 	void rdp_load_state(const uint8_t *state);

--- a/src/device/pi.rs
+++ b/src/device/pi.rs
@@ -1,4 +1,5 @@
 use crate::device;
+use crate::ui;
 use rand_chacha::rand_core::RngCore;
 
 const PI_DRAM_ADDR_REG: u32 = 0;
@@ -91,6 +92,9 @@ fn dma_write(device: &mut device::Device) {
     if length <= 0x80 {
         length -= dram_addr & 0x7;
     }
+
+    // check RDP before PI writes to RDRAM
+    ui::video::check_framebuffers(dram_addr, length);
 
     let cycles = (handler.write)(device, cart_addr, dram_addr, length);
 

--- a/src/device/rdram.rs
+++ b/src/device/rdram.rs
@@ -1,4 +1,5 @@
 use crate::device;
+use crate::ui;
 use std::alloc::{Layout, alloc_zeroed};
 
 //const RDRAM_CONFIG_REG: u32 = 0;
@@ -50,6 +51,8 @@ pub fn read_mem(
     );
     let masked_address = address as usize & RDRAM_MASK;
 
+    ui::video::check_framebuffers(masked_address as u32, 4);
+
     u32::from_ne_bytes(
         device
             .rdram
@@ -62,6 +65,8 @@ pub fn read_mem(
 }
 
 pub fn write_mem(device: &mut device::Device, address: u64, value: u32, mask: u32) {
+    ui::video::check_framebuffers(address as u32, 4);
+
     let mut data = u32::from_ne_bytes(
         device
             .rdram

--- a/src/device/rsp_interface.rs
+++ b/src/device/rsp_interface.rs
@@ -1,4 +1,5 @@
 use crate::device;
+use crate::ui;
 
 const SP_MEM_ADDR_REG: u32 = 0;
 const SP_DRAM_ADDR_REG: u32 = 1;
@@ -146,6 +147,7 @@ fn do_dma(device: &mut device::Device, dma: RspDma) {
     let mut dram_addr = dma.dramaddr & 0xfffff8;
     let offset = dma.memaddr & 0x1000;
 
+    ui::video::check_framebuffers(dram_addr, count * (length + skip) - skip);
     if dma.dir == DmaDir::Read {
         let mut j = 0;
         while j < count {

--- a/src/device/si.rs
+++ b/src/device/si.rs
@@ -1,6 +1,7 @@
 use rand_chacha::rand_core::RngCore;
 
 use crate::device;
+use crate::ui;
 
 const SI_DRAM_ADDR_REG: u32 = 0;
 const SI_PIF_ADDR_RD64B_REG: u32 = 1;
@@ -98,6 +99,8 @@ fn copy_pif_rdram(device: &mut device::Device) {
             i += 4;
         }
     } else if device.si.dma_dir == DmaDir::Read {
+        // check RDP before SI writes to RDRAM
+        ui::video::check_framebuffers(dram_addr as u32, device::pif::PIF_RAM_SIZE as u32);
         let mut i = 0;
         while i < device::pif::PIF_RAM_SIZE {
             let data = u32::from_be_bytes(device.pif.ram[i..i + 4].try_into().unwrap());

--- a/src/ui/video.rs
+++ b/src/ui/video.rs
@@ -192,6 +192,10 @@ pub fn process_rdp_list() -> u64 {
     unsafe { rdp_process_commands() }
 }
 
+pub fn check_framebuffers(address: u32, length: u32) {
+    unsafe { rdp_check_framebuffers(address, length) }
+}
+
 pub fn onscreen_message(_ui: &ui::Ui, message: &str) {
     unsafe { rdp_onscreen_message(std::ffi::CString::new(message).unwrap().as_ptr()) };
 }


### PR DESCRIPTION
Re-implementation of https://github.com/gopher64/gopher64/pull/381

Current issues:
* Corrupted text in Vigilante 2 (not always)