### PR TITLE
cargo: add features to choose origin of SDL3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,6 +4660,7 @@ checksum = "c531aa18059783450bcddc82a6effc48df5f173bb46142eb421ff2cfccf53984"
 dependencies = [
  "cc",
  "cmake",
+ "pkg-config",
  "rpkg-config",
  "sdl3-src",
 ]
@@ -4677,6 +4678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1d8477496fa2b081fb8f63cf8d0a9a9ba6a7a8f2a21b87e7d13d2ab6d73582"
 dependencies = [
  "cmake",
+ "pkg-config",
  "rpkg-config",
  "sdl3-sys",
  "sdl3-ttf-src",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ rust-version = "1.91"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = [ "sdl-build-from-source" ]
+sdl-build-from-source = [ "sdl3-sys/build-from-source-static", "sdl3-ttf-sys/build-from-source-static" ]
+sdl-use-pkg-config    = [ "sdl3-sys/use-pkg-config", "sdl3-ttf-sys/use-pkg-config" ]
+
 [dependencies]
 dirs = "6.0"
 zip = "6.0"
@@ -18,8 +23,8 @@ serde-big-array = "0.5"
 slint = { version = "1.12", default-features = false, features = ["compat-1-2", "std", "backend-winit", "renderer-skia-vulkan"] }
 open = "5.3"
 sha2 = "0.10"
-sdl3-sys = { version = "0.5", features = ["build-from-source-static"] }
-sdl3-ttf-sys = { version = "0.2", features = ["build-from-source-static", "no-sdlttf-harfbuzz", "no-sdlttf-plutosvg"] }
+sdl3-sys = { version = "0.5" }
+sdl3-ttf-sys = { version = "0.2", features = ["no-sdlttf-harfbuzz", "no-sdlttf-plutosvg"] }
 rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "tokio"] }
 tokio = {version = "1.46", features = ["rt-multi-thread", "macros"] }
 spin_sleep = "1.3"

--- a/build.rs
+++ b/build.rs
@@ -61,7 +61,10 @@ fn main() {
         .include("parallel-rdp/parallel-rdp-standalone/volk")
         .include("parallel-rdp/parallel-rdp-standalone/vulkan")
         .include("parallel-rdp/parallel-rdp-standalone/vulkan-headers/include")
-        .include("parallel-rdp/parallel-rdp-standalone/util")
+        .include("parallel-rdp/parallel-rdp-standalone/util");
+
+    #[cfg(feature="sdl-build-from-source")]
+    rdp_build
         .include(
             std::path::PathBuf::from(std::env::var("DEP_SDL3_OUT_DIR").to_owned().unwrap())
                 .join("include"),


### PR DESCRIPTION
Hi!
gopher64 is packaged on NixOS but outdated (1.0.17) so I wanted to update it (and automate the process) but it is not as straightforward as it could be .

Like probably all linux distros, packaging vendored dependencies is forbidden or at least very heavily discouraged, which means packagers have to maintains software patches to force the use of system libs.

It is usually easy, but with rust/cargo, it means changes in the `Cargo.lock` (in addition to `Cargo.toml`) and since this lock file can changes heavily at each cargo update, it means the patch we need to maintain breaks all the time and needs to be recreated from scratch, which is annoying and can't be automated easily. 

https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/go/gopher64/use-sdl3-via-pkg-config.patch

That's the reason why I'm suggesting you this PR to allow building gopher64 with SDL3 from the system, without using patches :)

I added two cargo features, one for SDL from source, and the other for taking it from pkg-config. The first one is enabled by default so the project works exactly as before by default.

If someone wants to use the system's SDL, they can run `cargo build --no-default-features --features sdl-use-pkg-config`.

