### PR TITLE
fix desync issue

### DIFF
--- a/src/netplay.rs
+++ b/src/netplay.rs
@@ -278,13 +278,26 @@ pub fn process_requests(
                     let hash = u128::from_be_bytes(hasher.finalize()[..16].try_into().unwrap());
                     cell.save(frame, Some(frame), Some(hash));
                 }
-                ggrs::GgrsRequest::LoadGameState { cell: _, frame: _ } => {
-                    // if let Some(frame) = cell.load() {
-                    //    savestates::load_savestate(device, true, Some(frame));
-                    // }
+                ggrs::GgrsRequest::LoadGameState { cell, frame: _ } => {
+                    if let Some(_frame) = cell.load() {
+                        //    savestates::load_savestate(device, true, Some(frame));
+                    }
                 }
                 ggrs::GgrsRequest::AdvanceFrame { inputs } => {
-                    return inputs;
+                    //workaround for disabled rollback
+                    if device.netplay.as_mut().unwrap().session.current_frame()
+                        > device.netplay.as_mut().unwrap().session.max_prediction() as i32
+                    {
+                        return inputs;
+                    } else {
+                        return vec![
+                            (
+                                ui::input::InputData::default(),
+                                ggrs::InputStatus::Predicted
+                            );
+                            4
+                        ];
+                    }
                 }
             }
         } else {
@@ -368,10 +381,7 @@ fn advance_frame(device: &mut device::Device) {
 
     match netplay.session.advance_frame() {
         Ok(requests) => {
-            //workaround for disabled rollback
-            if netplay.session.current_frame() > netplay.session.max_prediction() as i32 {
-                netplay.requests.extend(requests);
-            }
+            netplay.requests.extend(requests);
         }
         Err(ggrs::GgrsError::PredictionThreshold) => {
             println!("prediction threshold reached");

--- a/src/netplay.rs
+++ b/src/netplay.rs
@@ -339,7 +339,12 @@ fn process_netplay(device: &mut device::Device) {
 
 fn advance_frame(device: &mut device::Device) {
     let netplay = device.netplay.as_mut().unwrap();
-    let local_input = ui::input::get(&mut device.ui, 0, device.speed_limiter.frame_counter);
+    let local_input = if netplay.session.current_frame() > netplay.session.max_prediction() as i32 {
+        ui::input::get(&mut device.ui, 0, device.speed_limiter.frame_counter)
+    } else {
+        //workaround for disabled rollback
+        ui::input::InputData::default()
+    };
     let local_handle = *netplay.session.local_player_handles().first().unwrap();
     netplay
         .session

--- a/src/netplay.rs
+++ b/src/netplay.rs
@@ -284,10 +284,9 @@ pub fn process_requests(
                     }
                 }
                 ggrs::GgrsRequest::AdvanceFrame { inputs } => {
+                    let session = &device.netplay.as_mut().unwrap().session;
                     //workaround for disabled rollback
-                    if device.netplay.as_mut().unwrap().session.current_frame()
-                        > device.netplay.as_mut().unwrap().session.max_prediction() as i32
-                    {
+                    if session.current_frame() > session.max_prediction() as i32 {
                         return inputs;
                     } else {
                         return vec![

--- a/src/netplay.rs
+++ b/src/netplay.rs
@@ -279,24 +279,13 @@ pub fn process_requests(
                     cell.save(frame, Some(frame), Some(hash));
                 }
                 ggrs::GgrsRequest::LoadGameState { cell, frame: _ } => {
+                    eprintln!("attempting to load game state");
                     if let Some(_frame) = cell.load() {
                         //    savestates::load_savestate(device, true, Some(frame));
                     }
                 }
                 ggrs::GgrsRequest::AdvanceFrame { inputs } => {
-                    let session = &device.netplay.as_mut().unwrap().session;
-                    //workaround for disabled rollback
-                    if session.current_frame() > session.max_prediction() as i32 {
-                        return inputs;
-                    } else {
-                        return vec![
-                            (
-                                ui::input::InputData::default(),
-                                ggrs::InputStatus::Predicted
-                            );
-                            4
-                        ];
-                    }
+                    return inputs;
                 }
             }
         } else {

--- a/src/netplay.rs
+++ b/src/netplay.rs
@@ -368,7 +368,10 @@ fn advance_frame(device: &mut device::Device) {
 
     match netplay.session.advance_frame() {
         Ok(requests) => {
-            netplay.requests.extend(requests);
+            //workaround for disabled rollback
+            if netplay.session.current_frame() > netplay.session.max_prediction() as i32 {
+                netplay.requests.extend(requests);
+            }
         }
         Err(ggrs::GgrsError::PredictionThreshold) => {
             println!("prediction threshold reached");


### PR DESCRIPTION
Need to ensure that the current_frame is larger than the max_prediction window, or GGRS may try to use predicted inputs (thus triggering a rollback that we don't support)