### PR TITLE
settings: add a dark/light theme toggle

### DIFF
--- a/data/translations/de/LC_MESSAGES/gopher64.po
+++ b/data/translations/de/LC_MESSAGES/gopher64.po
@@ -499,22 +499,22 @@ msgstr "Auflösung:"
 #: src/ui/gui/settings_page.slint:52
 msgctxt "Settings"
 msgid "Theme:"
-msgstr ""
+msgstr "Thema:"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "System"
-msgstr ""
+msgstr "System"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Dark"
-msgstr ""
+msgstr "Dunkel"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Light"
-msgstr ""
+msgstr "Hell"
 
 #: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"

--- a/data/translations/de/LC_MESSAGES/gopher64.po
+++ b/data/translations/de/LC_MESSAGES/gopher64.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gopher64\n"
-"POT-Creation-Date: 2026-06-16 12:26+0000\n"
+"POT-Creation-Date: 2026-06-29 10:49+0000\n"
 "PO-Revision-Date: 2026-05-11 12:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: German\n"
@@ -47,37 +47,37 @@ msgctxt "About"
 msgid "Donate (via GitHub)"
 msgstr "Spenden (über GitHub)"
 
-#: src/ui/gui/appwindow.slint:148
+#: src/ui/gui/appwindow.slint:164
 msgctxt "Menu"
 msgid "Local Game"
 msgstr "Lokales Spiel"
 
-#: src/ui/gui/appwindow.slint:152
+#: src/ui/gui/appwindow.slint:168
 msgctxt "Menu"
 msgid "Controller Config"
 msgstr "Controller-Konfiguration"
 
-#: src/ui/gui/appwindow.slint:156
+#: src/ui/gui/appwindow.slint:172
 msgctxt "Menu"
 msgid "Netplay"
 msgstr "Netplay"
 
-#: src/ui/gui/appwindow.slint:160
+#: src/ui/gui/appwindow.slint:176
 msgctxt "Menu"
 msgid "Cheats"
 msgstr "Cheats"
 
-#: src/ui/gui/appwindow.slint:164
+#: src/ui/gui/appwindow.slint:180
 msgctxt "Menu"
 msgid "RetroAchievements"
 msgstr "RetroAchievements"
 
-#: src/ui/gui/appwindow.slint:168
+#: src/ui/gui/appwindow.slint:184
 msgctxt "Menu"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/ui/gui/appwindow.slint:172
+#: src/ui/gui/appwindow.slint:188
 msgctxt "Menu"
 msgid "About"
 msgstr "Über"
@@ -486,67 +486,87 @@ msgctxt "RetroAchievements"
 msgid "View Supported Games"
 msgstr "Unterstützte Spiele anzeigen"
 
-#: src/ui/gui/settings_page.slint:24
+#: src/ui/gui/settings_page.slint:25
 msgctxt "Settings"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/ui/gui/settings_page.slint:35
+#: src/ui/gui/settings_page.slint:36
 msgctxt "Settings"
 msgid "Resolution:"
 msgstr "Auflösung:"
 
-#: src/ui/gui/settings_page.slint:49
+#: src/ui/gui/settings_page.slint:52
+msgctxt "Settings"
+msgid "Theme:"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "System"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Dark"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Light"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"
 msgid "SSAA downscaling"
 msgstr "SSAA-Herunterskalierung"
 
-#: src/ui/gui/settings_page.slint:57
+#: src/ui/gui/settings_page.slint:74
 msgctxt "Settings"
 msgid "Integer Scaling"
 msgstr "Pixelgenaue Skalierung"
 
-#: src/ui/gui/settings_page.slint:65
+#: src/ui/gui/settings_page.slint:82
 msgctxt "Settings"
 msgid "Fullscreen"
 msgstr "Vollbild"
 
-#: src/ui/gui/settings_page.slint:73
+#: src/ui/gui/settings_page.slint:90
 msgctxt "Settings"
 msgid "Widescreen (stretch)"
 msgstr "16:9 (gestreckt)"
 
-#: src/ui/gui/settings_page.slint:81
+#: src/ui/gui/settings_page.slint:98
 msgctxt "Settings"
 msgid "VSync"
 msgstr "VSync"
 
-#: src/ui/gui/settings_page.slint:89
+#: src/ui/gui/settings_page.slint:106
 msgctxt "Settings"
 msgid "Apply CRT shader"
 msgstr "CRT-Shader anwenden"
 
-#: src/ui/gui/settings_page.slint:101
+#: src/ui/gui/settings_page.slint:118
 msgctxt "Settings"
 msgid "Overclock N64 CPU (may cause bugs)"
 msgstr "N64-CPU übertakten (kann Fehler verursachen)"
 
-#: src/ui/gui/settings_page.slint:109
+#: src/ui/gui/settings_page.slint:126
 msgctxt "Settings"
 msgid "Disable Expansion Pak"
 msgstr "Expansion Pak deaktivieren"
 
-#: src/ui/gui/settings_page.slint:117
+#: src/ui/gui/settings_page.slint:134
 msgctxt "Settings"
 msgid "Enable Rewind"
 msgstr "Rewind aktivieren"
 
-#: src/ui/gui/settings_page.slint:125
+#: src/ui/gui/settings_page.slint:142
 msgctxt "Settings"
 msgid "Emulate UNFLoader"
 msgstr "UNFLoader emulieren"
 
-#: src/ui/gui/settings_page.slint:133
+#: src/ui/gui/settings_page.slint:150
 msgctxt "Settings"
 msgid "Emulate VRU"
 msgstr "VRU emulieren"

--- a/data/translations/es/LC_MESSAGES/gopher64.po
+++ b/data/translations/es/LC_MESSAGES/gopher64.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gopher64\n"
-"POT-Creation-Date: 2026-06-16 12:26+0000\n"
+"POT-Creation-Date: 2026-06-29 10:49+0000\n"
 "PO-Revision-Date: 2026-05-11 12:00+0000\n"
 "Last-Translator: Gemini\n"
 "Language-Team: Spanish (Spain)\n"
@@ -47,37 +47,37 @@ msgctxt "About"
 msgid "Donate (via GitHub)"
 msgstr "Donar (a través de GitHub)"
 
-#: src/ui/gui/appwindow.slint:148
+#: src/ui/gui/appwindow.slint:164
 msgctxt "Menu"
 msgid "Local Game"
 msgstr "Juego local"
 
-#: src/ui/gui/appwindow.slint:152
+#: src/ui/gui/appwindow.slint:168
 msgctxt "Menu"
 msgid "Controller Config"
 msgstr "Config. del mando"
 
-#: src/ui/gui/appwindow.slint:156
+#: src/ui/gui/appwindow.slint:172
 msgctxt "Menu"
 msgid "Netplay"
 msgstr "Netplay"
 
-#: src/ui/gui/appwindow.slint:160
+#: src/ui/gui/appwindow.slint:176
 msgctxt "Menu"
 msgid "Cheats"
 msgstr "Trucos"
 
-#: src/ui/gui/appwindow.slint:164
+#: src/ui/gui/appwindow.slint:180
 msgctxt "Menu"
 msgid "RetroAchievements"
 msgstr "RetroAchievements"
 
-#: src/ui/gui/appwindow.slint:168
+#: src/ui/gui/appwindow.slint:184
 msgctxt "Menu"
 msgid "Settings"
 msgstr "Ajustes"
 
-#: src/ui/gui/appwindow.slint:172
+#: src/ui/gui/appwindow.slint:188
 msgctxt "Menu"
 msgid "About"
 msgstr "Acerca de"
@@ -399,8 +399,8 @@ msgid ""
 msgstr ""
 "Configurar un retardo de entrada demasiado bajo hará que el juego se "
 "ralentice.\n"
-"Puedes reducir el retardo de entrada en el juego pulsando Alt+[ y "
-"aumentarlo con Alt+]."
+"Puedes reducir el retardo de entrada en el juego pulsando Alt+[ y aumentarlo "
+"con Alt+]."
 
 #: src/ui/gui/netplay_wait.slint:101
 msgctxt "NetplayWait"
@@ -487,67 +487,87 @@ msgctxt "RetroAchievements"
 msgid "View Supported Games"
 msgstr "Ver juegos compatibles"
 
-#: src/ui/gui/settings_page.slint:24
+#: src/ui/gui/settings_page.slint:25
 msgctxt "Settings"
 msgid "Settings"
 msgstr "Ajustes"
 
-#: src/ui/gui/settings_page.slint:35
+#: src/ui/gui/settings_page.slint:36
 msgctxt "Settings"
 msgid "Resolution:"
 msgstr "Resolución:"
 
-#: src/ui/gui/settings_page.slint:49
+#: src/ui/gui/settings_page.slint:52
+msgctxt "Settings"
+msgid "Theme:"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "System"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Dark"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Light"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"
 msgid "SSAA downscaling"
 msgstr "Reducción de escala SSAA"
 
-#: src/ui/gui/settings_page.slint:57
+#: src/ui/gui/settings_page.slint:74
 msgctxt "Settings"
 msgid "Integer Scaling"
 msgstr "Escalado por enteros"
 
-#: src/ui/gui/settings_page.slint:65
+#: src/ui/gui/settings_page.slint:82
 msgctxt "Settings"
 msgid "Fullscreen"
 msgstr "Pantalla completa"
 
-#: src/ui/gui/settings_page.slint:73
+#: src/ui/gui/settings_page.slint:90
 msgctxt "Settings"
 msgid "Widescreen (stretch)"
 msgstr "Pantalla ancha (estirado)"
 
-#: src/ui/gui/settings_page.slint:81
+#: src/ui/gui/settings_page.slint:98
 msgctxt "Settings"
 msgid "VSync"
 msgstr "Sincronización vertical (VSync)"
 
-#: src/ui/gui/settings_page.slint:89
+#: src/ui/gui/settings_page.slint:106
 msgctxt "Settings"
 msgid "Apply CRT shader"
 msgstr "Aplicar sombreador CRT"
 
-#: src/ui/gui/settings_page.slint:101
+#: src/ui/gui/settings_page.slint:118
 msgctxt "Settings"
 msgid "Overclock N64 CPU (may cause bugs)"
 msgstr "Overclock CPU N64 (puede causar errores)"
 
-#: src/ui/gui/settings_page.slint:109
+#: src/ui/gui/settings_page.slint:126
 msgctxt "Settings"
 msgid "Disable Expansion Pak"
 msgstr "Desactivar Expansion Pak"
 
-#: src/ui/gui/settings_page.slint:117
+#: src/ui/gui/settings_page.slint:134
 msgctxt "Settings"
 msgid "Enable Rewind"
 msgstr "Activar rebobinado"
 
-#: src/ui/gui/settings_page.slint:125
+#: src/ui/gui/settings_page.slint:142
 msgctxt "Settings"
 msgid "Emulate UNFLoader"
 msgstr "Emular UNFLoader"
 
-#: src/ui/gui/settings_page.slint:133
+#: src/ui/gui/settings_page.slint:150
 msgctxt "Settings"
 msgid "Emulate VRU"
 msgstr "Emular VRU"

--- a/data/translations/es/LC_MESSAGES/gopher64.po
+++ b/data/translations/es/LC_MESSAGES/gopher64.po
@@ -500,22 +500,22 @@ msgstr "Resolución:"
 #: src/ui/gui/settings_page.slint:52
 msgctxt "Settings"
 msgid "Theme:"
-msgstr ""
+msgstr "Tema:"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "System"
-msgstr ""
+msgstr "Sistema"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Dark"
-msgstr ""
+msgstr "Oscuro"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Light"
-msgstr ""
+msgstr "Claro"
 
 #: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"

--- a/data/translations/fr/LC_MESSAGES/gopher64.po
+++ b/data/translations/fr/LC_MESSAGES/gopher64.po
@@ -500,22 +500,22 @@ msgstr "Résolution :"
 #: src/ui/gui/settings_page.slint:52
 msgctxt "Settings"
 msgid "Theme:"
-msgstr ""
+msgstr "Thème :"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "System"
-msgstr ""
+msgstr "Système"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Dark"
-msgstr ""
+msgstr "Sombre"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Light"
-msgstr ""
+msgstr "Clair"
 
 #: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"

--- a/data/translations/fr/LC_MESSAGES/gopher64.po
+++ b/data/translations/fr/LC_MESSAGES/gopher64.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gopher64\n"
-"POT-Creation-Date: 2026-06-16 12:26+0000\n"
+"POT-Creation-Date: 2026-06-29 10:49+0000\n"
 "PO-Revision-Date: 2026-05-11 12:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: French (France)\n"
@@ -47,37 +47,37 @@ msgctxt "About"
 msgid "Donate (via GitHub)"
 msgstr "Faire un don (via GitHub)"
 
-#: src/ui/gui/appwindow.slint:148
+#: src/ui/gui/appwindow.slint:164
 msgctxt "Menu"
 msgid "Local Game"
 msgstr "Jeu local"
 
-#: src/ui/gui/appwindow.slint:152
+#: src/ui/gui/appwindow.slint:168
 msgctxt "Menu"
 msgid "Controller Config"
 msgstr "Configuration manette"
 
-#: src/ui/gui/appwindow.slint:156
+#: src/ui/gui/appwindow.slint:172
 msgctxt "Menu"
 msgid "Netplay"
 msgstr "Netplay"
 
-#: src/ui/gui/appwindow.slint:160
+#: src/ui/gui/appwindow.slint:176
 msgctxt "Menu"
 msgid "Cheats"
 msgstr "Triche"
 
-#: src/ui/gui/appwindow.slint:164
+#: src/ui/gui/appwindow.slint:180
 msgctxt "Menu"
 msgid "RetroAchievements"
 msgstr "RetroAchievements"
 
-#: src/ui/gui/appwindow.slint:168
+#: src/ui/gui/appwindow.slint:184
 msgctxt "Menu"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: src/ui/gui/appwindow.slint:172
+#: src/ui/gui/appwindow.slint:188
 msgctxt "Menu"
 msgid "About"
 msgstr "À propos"
@@ -399,8 +399,8 @@ msgid ""
 "Alt+]."
 msgstr ""
 "Régler le délai d'entrée trop bas provoquera des ralentissements.\n"
-"Vous pouvez diminuer le délai d'entrée en jeu avec Alt+[ et l'augmenter "
-"avec Alt+]."
+"Vous pouvez diminuer le délai d'entrée en jeu avec Alt+[ et l'augmenter avec "
+"Alt+]."
 
 #: src/ui/gui/netplay_wait.slint:101
 msgctxt "NetplayWait"
@@ -487,67 +487,87 @@ msgctxt "RetroAchievements"
 msgid "View Supported Games"
 msgstr "Voir les jeux pris en charge"
 
-#: src/ui/gui/settings_page.slint:24
+#: src/ui/gui/settings_page.slint:25
 msgctxt "Settings"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: src/ui/gui/settings_page.slint:35
+#: src/ui/gui/settings_page.slint:36
 msgctxt "Settings"
 msgid "Resolution:"
 msgstr "Résolution :"
 
-#: src/ui/gui/settings_page.slint:49
+#: src/ui/gui/settings_page.slint:52
+msgctxt "Settings"
+msgid "Theme:"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "System"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Dark"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Light"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"
 msgid "SSAA downscaling"
 msgstr "Réduction SSAA"
 
-#: src/ui/gui/settings_page.slint:57
+#: src/ui/gui/settings_page.slint:74
 msgctxt "Settings"
 msgid "Integer Scaling"
 msgstr "Mise à l'échelle par entiers"
 
-#: src/ui/gui/settings_page.slint:65
+#: src/ui/gui/settings_page.slint:82
 msgctxt "Settings"
 msgid "Fullscreen"
 msgstr "Plein écran"
 
-#: src/ui/gui/settings_page.slint:73
+#: src/ui/gui/settings_page.slint:90
 msgctxt "Settings"
 msgid "Widescreen (stretch)"
 msgstr "Écran large (étiré)"
 
-#: src/ui/gui/settings_page.slint:81
+#: src/ui/gui/settings_page.slint:98
 msgctxt "Settings"
 msgid "VSync"
 msgstr "Synchro verticale"
 
-#: src/ui/gui/settings_page.slint:89
+#: src/ui/gui/settings_page.slint:106
 msgctxt "Settings"
 msgid "Apply CRT shader"
 msgstr "Appliquer le filtre CRT"
 
-#: src/ui/gui/settings_page.slint:101
+#: src/ui/gui/settings_page.slint:118
 msgctxt "Settings"
 msgid "Overclock N64 CPU (may cause bugs)"
 msgstr "Surcharger le CPU N64 (risque de bugs)"
 
-#: src/ui/gui/settings_page.slint:109
+#: src/ui/gui/settings_page.slint:126
 msgctxt "Settings"
 msgid "Disable Expansion Pak"
 msgstr "Désactiver l'Expansion Pak"
 
-#: src/ui/gui/settings_page.slint:117
+#: src/ui/gui/settings_page.slint:134
 msgctxt "Settings"
 msgid "Enable Rewind"
 msgstr "Activer le rembobinage"
 
-#: src/ui/gui/settings_page.slint:125
+#: src/ui/gui/settings_page.slint:142
 msgctxt "Settings"
 msgid "Emulate UNFLoader"
 msgstr "Émuler UNFLoader"
 
-#: src/ui/gui/settings_page.slint:133
+#: src/ui/gui/settings_page.slint:150
 msgctxt "Settings"
 msgid "Emulate VRU"
 msgstr "Émuler le VRU"

--- a/data/translations/gopher64.pot
+++ b/data/translations/gopher64.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-16 12:26+0000\n"
+"POT-Creation-Date: 2026-06-29 10:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,37 +47,37 @@ msgctxt "About"
 msgid "Donate (via GitHub)"
 msgstr ""
 
-#: src/ui/gui/appwindow.slint:148
+#: src/ui/gui/appwindow.slint:164
 msgctxt "Menu"
 msgid "Local Game"
 msgstr ""
 
-#: src/ui/gui/appwindow.slint:152
+#: src/ui/gui/appwindow.slint:168
 msgctxt "Menu"
 msgid "Controller Config"
 msgstr ""
 
-#: src/ui/gui/appwindow.slint:156
+#: src/ui/gui/appwindow.slint:172
 msgctxt "Menu"
 msgid "Netplay"
 msgstr ""
 
-#: src/ui/gui/appwindow.slint:160
+#: src/ui/gui/appwindow.slint:176
 msgctxt "Menu"
 msgid "Cheats"
 msgstr ""
 
-#: src/ui/gui/appwindow.slint:164
+#: src/ui/gui/appwindow.slint:180
 msgctxt "Menu"
 msgid "RetroAchievements"
 msgstr ""
 
-#: src/ui/gui/appwindow.slint:168
+#: src/ui/gui/appwindow.slint:184
 msgctxt "Menu"
 msgid "Settings"
 msgstr ""
 
-#: src/ui/gui/appwindow.slint:172
+#: src/ui/gui/appwindow.slint:188
 msgctxt "Menu"
 msgid "About"
 msgstr ""
@@ -480,67 +480,87 @@ msgctxt "RetroAchievements"
 msgid "View Supported Games"
 msgstr ""
 
-#: src/ui/gui/settings_page.slint:24
+#: src/ui/gui/settings_page.slint:25
 msgctxt "Settings"
 msgid "Settings"
 msgstr ""
 
-#: src/ui/gui/settings_page.slint:35
+#: src/ui/gui/settings_page.slint:36
 msgctxt "Settings"
 msgid "Resolution:"
 msgstr ""
 
-#: src/ui/gui/settings_page.slint:49
+#: src/ui/gui/settings_page.slint:52
 msgctxt "Settings"
-msgid "SSAA downscaling"
+msgid "Theme:"
 msgstr ""
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
+msgid "System"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Dark"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Light"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:66
+msgctxt "Settings"
+msgid "SSAA downscaling"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:74
+msgctxt "Settings"
 msgid "Integer Scaling"
 msgstr ""
 
-#: src/ui/gui/settings_page.slint:65
+#: src/ui/gui/settings_page.slint:82
 msgctxt "Settings"
 msgid "Fullscreen"
 msgstr ""
 
-#: src/ui/gui/settings_page.slint:73
+#: src/ui/gui/settings_page.slint:90
 msgctxt "Settings"
 msgid "Widescreen (stretch)"
 msgstr ""
 
-#: src/ui/gui/settings_page.slint:81
+#: src/ui/gui/settings_page.slint:98
 msgctxt "Settings"
 msgid "VSync"
 msgstr ""
 
-#: src/ui/gui/settings_page.slint:89
+#: src/ui/gui/settings_page.slint:106
 msgctxt "Settings"
 msgid "Apply CRT shader"
 msgstr ""
 
-#: src/ui/gui/settings_page.slint:101
+#: src/ui/gui/settings_page.slint:118
 msgctxt "Settings"
 msgid "Overclock N64 CPU (may cause bugs)"
 msgstr ""
 
-#: src/ui/gui/settings_page.slint:109
+#: src/ui/gui/settings_page.slint:126
 msgctxt "Settings"
 msgid "Disable Expansion Pak"
 msgstr ""
 
-#: src/ui/gui/settings_page.slint:117
+#: src/ui/gui/settings_page.slint:134
 msgctxt "Settings"
 msgid "Enable Rewind"
 msgstr ""
 
-#: src/ui/gui/settings_page.slint:125
+#: src/ui/gui/settings_page.slint:142
 msgctxt "Settings"
 msgid "Emulate UNFLoader"
 msgstr ""
 
-#: src/ui/gui/settings_page.slint:133
+#: src/ui/gui/settings_page.slint:150
 msgctxt "Settings"
 msgid "Emulate VRU"
 msgstr ""

--- a/data/translations/ja/LC_MESSAGES/gopher64.po
+++ b/data/translations/ja/LC_MESSAGES/gopher64.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gopher64\n"
-"POT-Creation-Date: 2026-06-16 12:26+0000\n"
+"POT-Creation-Date: 2026-06-29 10:49+0000\n"
 "PO-Revision-Date: 2026-05-11 12:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -47,37 +47,37 @@ msgctxt "About"
 msgid "Donate (via GitHub)"
 msgstr "GitHubで寄付"
 
-#: src/ui/gui/appwindow.slint:148
+#: src/ui/gui/appwindow.slint:164
 msgctxt "Menu"
 msgid "Local Game"
 msgstr "ローカルゲーム"
 
-#: src/ui/gui/appwindow.slint:152
+#: src/ui/gui/appwindow.slint:168
 msgctxt "Menu"
 msgid "Controller Config"
 msgstr "コントローラー設定"
 
-#: src/ui/gui/appwindow.slint:156
+#: src/ui/gui/appwindow.slint:172
 msgctxt "Menu"
 msgid "Netplay"
 msgstr "ネットプレイ"
 
-#: src/ui/gui/appwindow.slint:160
+#: src/ui/gui/appwindow.slint:176
 msgctxt "Menu"
 msgid "Cheats"
 msgstr "チート"
 
-#: src/ui/gui/appwindow.slint:164
+#: src/ui/gui/appwindow.slint:180
 msgctxt "Menu"
 msgid "RetroAchievements"
 msgstr "RetroAchievements"
 
-#: src/ui/gui/appwindow.slint:168
+#: src/ui/gui/appwindow.slint:184
 msgctxt "Menu"
 msgid "Settings"
 msgstr "設定"
 
-#: src/ui/gui/appwindow.slint:172
+#: src/ui/gui/appwindow.slint:188
 msgctxt "Menu"
 msgid "About"
 msgstr "バージョン情報"
@@ -483,67 +483,87 @@ msgctxt "RetroAchievements"
 msgid "View Supported Games"
 msgstr "対応ゲームを表示"
 
-#: src/ui/gui/settings_page.slint:24
+#: src/ui/gui/settings_page.slint:25
 msgctxt "Settings"
 msgid "Settings"
 msgstr "設定"
 
-#: src/ui/gui/settings_page.slint:35
+#: src/ui/gui/settings_page.slint:36
 msgctxt "Settings"
 msgid "Resolution:"
 msgstr "解像度："
 
-#: src/ui/gui/settings_page.slint:49
+#: src/ui/gui/settings_page.slint:52
+msgctxt "Settings"
+msgid "Theme:"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "System"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Dark"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Light"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"
 msgid "SSAA downscaling"
 msgstr "SSAAダウンスケール"
 
-#: src/ui/gui/settings_page.slint:57
+#: src/ui/gui/settings_page.slint:74
 msgctxt "Settings"
 msgid "Integer Scaling"
 msgstr "整数倍スケーリング"
 
-#: src/ui/gui/settings_page.slint:65
+#: src/ui/gui/settings_page.slint:82
 msgctxt "Settings"
 msgid "Fullscreen"
 msgstr "全画面表示"
 
-#: src/ui/gui/settings_page.slint:73
+#: src/ui/gui/settings_page.slint:90
 msgctxt "Settings"
 msgid "Widescreen (stretch)"
 msgstr "ワイド画面（伸ばす）"
 
-#: src/ui/gui/settings_page.slint:81
+#: src/ui/gui/settings_page.slint:98
 msgctxt "Settings"
 msgid "VSync"
 msgstr "垂直同期（VSync）"
 
-#: src/ui/gui/settings_page.slint:89
+#: src/ui/gui/settings_page.slint:106
 msgctxt "Settings"
 msgid "Apply CRT shader"
 msgstr "CRTシェーダーを適用"
 
-#: src/ui/gui/settings_page.slint:101
+#: src/ui/gui/settings_page.slint:118
 msgctxt "Settings"
 msgid "Overclock N64 CPU (may cause bugs)"
 msgstr "N64のCPUをオーバークロック（不具合の原因になることがあります）"
 
-#: src/ui/gui/settings_page.slint:109
+#: src/ui/gui/settings_page.slint:126
 msgctxt "Settings"
 msgid "Disable Expansion Pak"
 msgstr "拡張パックを無効にする"
 
-#: src/ui/gui/settings_page.slint:117
+#: src/ui/gui/settings_page.slint:134
 msgctxt "Settings"
 msgid "Enable Rewind"
 msgstr "巻き戻しを有効にする"
 
-#: src/ui/gui/settings_page.slint:125
+#: src/ui/gui/settings_page.slint:142
 msgctxt "Settings"
 msgid "Emulate UNFLoader"
 msgstr "UNFLoaderをエミュレート"
 
-#: src/ui/gui/settings_page.slint:133
+#: src/ui/gui/settings_page.slint:150
 msgctxt "Settings"
 msgid "Emulate VRU"
 msgstr "VRUをエミュレート"

--- a/data/translations/ja/LC_MESSAGES/gopher64.po
+++ b/data/translations/ja/LC_MESSAGES/gopher64.po
@@ -496,22 +496,22 @@ msgstr "解像度："
 #: src/ui/gui/settings_page.slint:52
 msgctxt "Settings"
 msgid "Theme:"
-msgstr ""
+msgstr "テーマ:"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "System"
-msgstr ""
+msgstr "システム"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Dark"
-msgstr ""
+msgstr "ダーク"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Light"
-msgstr ""
+msgstr "ライト"
 
 #: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"

--- a/data/translations/nl/LC_MESSAGES/gopher64.po
+++ b/data/translations/nl/LC_MESSAGES/gopher64.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gopher64\n"
-"POT-Creation-Date: 2026-06-16 12:26+0000\n"
+"POT-Creation-Date: 2026-06-29 10:49+0000\n"
 "PO-Revision-Date: 2026-05-11 12:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: Dutch (Netherlands)\n"
@@ -47,37 +47,37 @@ msgctxt "About"
 msgid "Donate (via GitHub)"
 msgstr "Doneren (via GitHub)"
 
-#: src/ui/gui/appwindow.slint:148
+#: src/ui/gui/appwindow.slint:164
 msgctxt "Menu"
 msgid "Local Game"
 msgstr "Lokaal spel"
 
-#: src/ui/gui/appwindow.slint:152
+#: src/ui/gui/appwindow.slint:168
 msgctxt "Menu"
 msgid "Controller Config"
 msgstr "Controllerconfiguratie"
 
-#: src/ui/gui/appwindow.slint:156
+#: src/ui/gui/appwindow.slint:172
 msgctxt "Menu"
 msgid "Netplay"
 msgstr "Netplay"
 
-#: src/ui/gui/appwindow.slint:160
+#: src/ui/gui/appwindow.slint:176
 msgctxt "Menu"
 msgid "Cheats"
 msgstr "Cheats"
 
-#: src/ui/gui/appwindow.slint:164
+#: src/ui/gui/appwindow.slint:180
 msgctxt "Menu"
 msgid "RetroAchievements"
 msgstr "RetroAchievements"
 
-#: src/ui/gui/appwindow.slint:168
+#: src/ui/gui/appwindow.slint:184
 msgctxt "Menu"
 msgid "Settings"
 msgstr "Instellingen"
 
-#: src/ui/gui/appwindow.slint:172
+#: src/ui/gui/appwindow.slint:188
 msgctxt "Menu"
 msgid "About"
 msgstr "Over"
@@ -486,67 +486,87 @@ msgctxt "RetroAchievements"
 msgid "View Supported Games"
 msgstr "Ondersteunde spellen bekijken"
 
-#: src/ui/gui/settings_page.slint:24
+#: src/ui/gui/settings_page.slint:25
 msgctxt "Settings"
 msgid "Settings"
 msgstr "Instellingen"
 
-#: src/ui/gui/settings_page.slint:35
+#: src/ui/gui/settings_page.slint:36
 msgctxt "Settings"
 msgid "Resolution:"
 msgstr "Resolutie:"
 
-#: src/ui/gui/settings_page.slint:49
+#: src/ui/gui/settings_page.slint:52
+msgctxt "Settings"
+msgid "Theme:"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "System"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Dark"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Light"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"
 msgid "SSAA downscaling"
 msgstr "SSAA-downscaling"
 
-#: src/ui/gui/settings_page.slint:57
+#: src/ui/gui/settings_page.slint:74
 msgctxt "Settings"
 msgid "Integer Scaling"
 msgstr "Schalen in hele getallen"
 
-#: src/ui/gui/settings_page.slint:65
+#: src/ui/gui/settings_page.slint:82
 msgctxt "Settings"
 msgid "Fullscreen"
 msgstr "Volledig scherm"
 
-#: src/ui/gui/settings_page.slint:73
+#: src/ui/gui/settings_page.slint:90
 msgctxt "Settings"
 msgid "Widescreen (stretch)"
 msgstr "Breedbeeld (uitgerekt)"
 
-#: src/ui/gui/settings_page.slint:81
+#: src/ui/gui/settings_page.slint:98
 msgctxt "Settings"
 msgid "VSync"
 msgstr "VSync"
 
-#: src/ui/gui/settings_page.slint:89
+#: src/ui/gui/settings_page.slint:106
 msgctxt "Settings"
 msgid "Apply CRT shader"
 msgstr "CRT-shader toepassen"
 
-#: src/ui/gui/settings_page.slint:101
+#: src/ui/gui/settings_page.slint:118
 msgctxt "Settings"
 msgid "Overclock N64 CPU (may cause bugs)"
 msgstr "N64-CPU overklokken (kan bugs veroorzaken)"
 
-#: src/ui/gui/settings_page.slint:109
+#: src/ui/gui/settings_page.slint:126
 msgctxt "Settings"
 msgid "Disable Expansion Pak"
 msgstr "Expansion Pak uitschakelen"
 
-#: src/ui/gui/settings_page.slint:117
+#: src/ui/gui/settings_page.slint:134
 msgctxt "Settings"
 msgid "Enable Rewind"
 msgstr "Terugspoelen inschakelen"
 
-#: src/ui/gui/settings_page.slint:125
+#: src/ui/gui/settings_page.slint:142
 msgctxt "Settings"
 msgid "Emulate UNFLoader"
 msgstr "UNFLoader emuleren"
 
-#: src/ui/gui/settings_page.slint:133
+#: src/ui/gui/settings_page.slint:150
 msgctxt "Settings"
 msgid "Emulate VRU"
 msgstr "VRU emuleren"

--- a/data/translations/nl/LC_MESSAGES/gopher64.po
+++ b/data/translations/nl/LC_MESSAGES/gopher64.po
@@ -499,22 +499,22 @@ msgstr "Resolutie:"
 #: src/ui/gui/settings_page.slint:52
 msgctxt "Settings"
 msgid "Theme:"
-msgstr ""
+msgstr "Thema:"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "System"
-msgstr ""
+msgstr "Systeem"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Dark"
-msgstr ""
+msgstr "Donker"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Light"
-msgstr ""
+msgstr "Licht"
 
 #: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"

--- a/data/translations/pt_BR/LC_MESSAGES/gopher64.po
+++ b/data/translations/pt_BR/LC_MESSAGES/gopher64.po
@@ -500,22 +500,22 @@ msgstr "Resolução:"
 #: src/ui/gui/settings_page.slint:52
 msgctxt "Settings"
 msgid "Theme:"
-msgstr ""
+msgstr "Tema:"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "System"
-msgstr ""
+msgstr "Sistema"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Dark"
-msgstr ""
+msgstr "Escuro"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Light"
-msgstr ""
+msgstr "Claro"
 
 #: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"

--- a/data/translations/pt_BR/LC_MESSAGES/gopher64.po
+++ b/data/translations/pt_BR/LC_MESSAGES/gopher64.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-16 12:26+0000\n"
+"POT-Creation-Date: 2026-06-29 10:49+0000\n"
 "PO-Revision-Date: 2026-05-11 18:11-3000\n"
 "Last-Translator: EDUARDO CARVALHO <eduardotcarvalho@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,37 +47,37 @@ msgctxt "About"
 msgid "Donate (via GitHub)"
 msgstr "Doações (via GitHub)"
 
-#: src/ui/gui/appwindow.slint:148
+#: src/ui/gui/appwindow.slint:164
 msgctxt "Menu"
 msgid "Local Game"
 msgstr "Jogo Local"
 
-#: src/ui/gui/appwindow.slint:152
+#: src/ui/gui/appwindow.slint:168
 msgctxt "Menu"
 msgid "Controller Config"
 msgstr "Configurar Controle"
 
-#: src/ui/gui/appwindow.slint:156
+#: src/ui/gui/appwindow.slint:172
 msgctxt "Menu"
 msgid "Netplay"
 msgstr "Netplay"
 
-#: src/ui/gui/appwindow.slint:160
+#: src/ui/gui/appwindow.slint:176
 msgctxt "Menu"
 msgid "Cheats"
 msgstr "Trapaças"
 
-#: src/ui/gui/appwindow.slint:164
+#: src/ui/gui/appwindow.slint:180
 msgctxt "Menu"
 msgid "RetroAchievements"
 msgstr "RetroAchievements"
 
-#: src/ui/gui/appwindow.slint:168
+#: src/ui/gui/appwindow.slint:184
 msgctxt "Menu"
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/ui/gui/appwindow.slint:172
+#: src/ui/gui/appwindow.slint:188
 msgctxt "Menu"
 msgid "About"
 msgstr "Sobre"
@@ -399,8 +399,8 @@ msgid ""
 "Alt+]."
 msgstr ""
 "Definir o atraso de entrada muito baixo causará lag no jogo.\n"
-"Você pode diminuir o atraso de entrada no jogo pressionando Alt+[ e "
-"aumentá-lo com Alt+]."
+"Você pode diminuir o atraso de entrada no jogo pressionando Alt+[ e aumentá-"
+"lo com Alt+]."
 
 #: src/ui/gui/netplay_wait.slint:101
 msgctxt "NetplayWait"
@@ -487,67 +487,87 @@ msgctxt "RetroAchievements"
 msgid "View Supported Games"
 msgstr "Ver Jogos com Suporte"
 
-#: src/ui/gui/settings_page.slint:24
+#: src/ui/gui/settings_page.slint:25
 msgctxt "Settings"
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/ui/gui/settings_page.slint:35
+#: src/ui/gui/settings_page.slint:36
 msgctxt "Settings"
 msgid "Resolution:"
 msgstr "Resolução:"
 
-#: src/ui/gui/settings_page.slint:49
+#: src/ui/gui/settings_page.slint:52
+msgctxt "Settings"
+msgid "Theme:"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "System"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Dark"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Light"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"
 msgid "SSAA downscaling"
 msgstr "Redução de SSAA"
 
-#: src/ui/gui/settings_page.slint:57
+#: src/ui/gui/settings_page.slint:74
 msgctxt "Settings"
 msgid "Integer Scaling"
 msgstr "Proporção Íntegra"
 
-#: src/ui/gui/settings_page.slint:65
+#: src/ui/gui/settings_page.slint:82
 msgctxt "Settings"
 msgid "Fullscreen"
 msgstr "Tela Cheia"
 
-#: src/ui/gui/settings_page.slint:73
+#: src/ui/gui/settings_page.slint:90
 msgctxt "Settings"
 msgid "Widescreen (stretch)"
 msgstr "Widescreen (esticar)"
 
-#: src/ui/gui/settings_page.slint:81
+#: src/ui/gui/settings_page.slint:98
 msgctxt "Settings"
 msgid "VSync"
 msgstr "VSync"
 
-#: src/ui/gui/settings_page.slint:89
+#: src/ui/gui/settings_page.slint:106
 msgctxt "Settings"
 msgid "Apply CRT shader"
 msgstr "Aplicar filtro de CRT"
 
-#: src/ui/gui/settings_page.slint:101
+#: src/ui/gui/settings_page.slint:118
 msgctxt "Settings"
 msgid "Overclock N64 CPU (may cause bugs)"
 msgstr "Overclock da CPU do N64 (pode causar bugs)"
 
-#: src/ui/gui/settings_page.slint:109
+#: src/ui/gui/settings_page.slint:126
 msgctxt "Settings"
 msgid "Disable Expansion Pak"
 msgstr "Desabilitar Expansion Pak"
 
-#: src/ui/gui/settings_page.slint:117
+#: src/ui/gui/settings_page.slint:134
 msgctxt "Settings"
 msgid "Enable Rewind"
 msgstr "Habilitar rebobinamento"
 
-#: src/ui/gui/settings_page.slint:125
+#: src/ui/gui/settings_page.slint:142
 msgctxt "Settings"
 msgid "Emulate UNFLoader"
 msgstr "Emular UNFLoader"
 
-#: src/ui/gui/settings_page.slint:133
+#: src/ui/gui/settings_page.slint:150
 msgctxt "Settings"
 msgid "Emulate VRU"
 msgstr "Emular VRU"

--- a/data/translations/ru/LC_MESSAGES/gopher64.po
+++ b/data/translations/ru/LC_MESSAGES/gopher64.po
@@ -498,22 +498,22 @@ msgstr "Разрешение:"
 #: src/ui/gui/settings_page.slint:52
 msgctxt "Settings"
 msgid "Theme:"
-msgstr ""
+msgstr "Тема:"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "System"
-msgstr ""
+msgstr "Система"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Dark"
-msgstr ""
+msgstr "Тёмная"
 
 #: src/ui/gui/settings_page.slint:57
 msgctxt "Settings"
 msgid "Light"
-msgstr ""
+msgstr "Светлая"
 
 #: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"

--- a/data/translations/ru/LC_MESSAGES/gopher64.po
+++ b/data/translations/ru/LC_MESSAGES/gopher64.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gopher64\n"
-"POT-Creation-Date: 2026-06-16 12:26+0000\n"
+"POT-Creation-Date: 2026-06-29 10:49+0000\n"
 "PO-Revision-Date: 2026-05-11 12:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: Russian\n"
@@ -47,37 +47,37 @@ msgctxt "About"
 msgid "Donate (via GitHub)"
 msgstr "Пожертвовать (через GitHub)"
 
-#: src/ui/gui/appwindow.slint:148
+#: src/ui/gui/appwindow.slint:164
 msgctxt "Menu"
 msgid "Local Game"
 msgstr "Локальная игра"
 
-#: src/ui/gui/appwindow.slint:152
+#: src/ui/gui/appwindow.slint:168
 msgctxt "Menu"
 msgid "Controller Config"
 msgstr "Настройка контроллера"
 
-#: src/ui/gui/appwindow.slint:156
+#: src/ui/gui/appwindow.slint:172
 msgctxt "Menu"
 msgid "Netplay"
 msgstr "Сетевая игра"
 
-#: src/ui/gui/appwindow.slint:160
+#: src/ui/gui/appwindow.slint:176
 msgctxt "Menu"
 msgid "Cheats"
 msgstr "Читы"
 
-#: src/ui/gui/appwindow.slint:164
+#: src/ui/gui/appwindow.slint:180
 msgctxt "Menu"
 msgid "RetroAchievements"
 msgstr "RetroAchievements"
 
-#: src/ui/gui/appwindow.slint:168
+#: src/ui/gui/appwindow.slint:184
 msgctxt "Menu"
 msgid "Settings"
 msgstr "Настройки"
 
-#: src/ui/gui/appwindow.slint:172
+#: src/ui/gui/appwindow.slint:188
 msgctxt "Menu"
 msgid "About"
 msgstr "О программе"
@@ -485,67 +485,87 @@ msgctxt "RetroAchievements"
 msgid "View Supported Games"
 msgstr "Просмотреть поддерживаемые игры"
 
-#: src/ui/gui/settings_page.slint:24
+#: src/ui/gui/settings_page.slint:25
 msgctxt "Settings"
 msgid "Settings"
 msgstr "Настройки"
 
-#: src/ui/gui/settings_page.slint:35
+#: src/ui/gui/settings_page.slint:36
 msgctxt "Settings"
 msgid "Resolution:"
 msgstr "Разрешение:"
 
-#: src/ui/gui/settings_page.slint:49
+#: src/ui/gui/settings_page.slint:52
+msgctxt "Settings"
+msgid "Theme:"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "System"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Dark"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:57
+msgctxt "Settings"
+msgid "Light"
+msgstr ""
+
+#: src/ui/gui/settings_page.slint:66
 msgctxt "Settings"
 msgid "SSAA downscaling"
 msgstr "SSAA даунскейлинг"
 
-#: src/ui/gui/settings_page.slint:57
+#: src/ui/gui/settings_page.slint:74
 msgctxt "Settings"
 msgid "Integer Scaling"
 msgstr "Целочисленное масштабирование"
 
-#: src/ui/gui/settings_page.slint:65
+#: src/ui/gui/settings_page.slint:82
 msgctxt "Settings"
 msgid "Fullscreen"
 msgstr "Полноэкранный режим"
 
-#: src/ui/gui/settings_page.slint:73
+#: src/ui/gui/settings_page.slint:90
 msgctxt "Settings"
 msgid "Widescreen (stretch)"
 msgstr "Широкоэкранный режим (растянуто)"
 
-#: src/ui/gui/settings_page.slint:81
+#: src/ui/gui/settings_page.slint:98
 msgctxt "Settings"
 msgid "VSync"
 msgstr "Вертикальная синхронизация"
 
-#: src/ui/gui/settings_page.slint:89
+#: src/ui/gui/settings_page.slint:106
 msgctxt "Settings"
 msgid "Apply CRT shader"
 msgstr "Применить шейдер ЭЛТ"
 
-#: src/ui/gui/settings_page.slint:101
+#: src/ui/gui/settings_page.slint:118
 msgctxt "Settings"
 msgid "Overclock N64 CPU (may cause bugs)"
 msgstr "Разгон процессора N64 (может вызвать ошибки)"
 
-#: src/ui/gui/settings_page.slint:109
+#: src/ui/gui/settings_page.slint:126
 msgctxt "Settings"
 msgid "Disable Expansion Pak"
 msgstr "Отключить Expansion Pak"
 
-#: src/ui/gui/settings_page.slint:117
+#: src/ui/gui/settings_page.slint:134
 msgctxt "Settings"
 msgid "Enable Rewind"
 msgstr "Включить перемотку назад"
 
-#: src/ui/gui/settings_page.slint:125
+#: src/ui/gui/settings_page.slint:142
 msgctxt "Settings"
 msgid "Emulate UNFLoader"
 msgstr "Эмулировать UNFLoader"
 
-#: src/ui/gui/settings_page.slint:133
+#: src/ui/gui/settings_page.slint:150
 msgctxt "Settings"
 msgid "Emulate VRU"
 msgstr "Эмулировать VRU"

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -54,6 +54,8 @@ pub struct Video {
     pub widescreen: bool,
     pub vsync: bool,
     pub crt: bool,
+    #[serde(default)]
+    pub theme: i32,
 }
 
 #[derive(Default, serde::Serialize, serde::Deserialize)]
@@ -179,6 +181,7 @@ impl Config {
                 widescreen: false,
                 vsync: true,
                 crt: false,
+                theme: 0,
             },
             emulation: Emulation {
                 overclock: false,

--- a/src/ui/gui.rs
+++ b/src/ui/gui.rs
@@ -179,6 +179,7 @@ fn settings_window(app: &AppWindow, config: &ui::config::Config) {
     app.set_widescreen(config.video.widescreen);
     app.set_vsync(config.video.vsync);
     app.set_apply_crt_shader(config.video.crt);
+    app.set_theme(config.video.theme);
     app.set_overclock_n64_cpu(config.emulation.overclock);
     app.set_disable_expansion_pak(config.emulation.disable_expansion_pak);
     app.set_emulate_usb(config.emulation.usb);
@@ -451,6 +452,7 @@ pub fn save_settings(app: &AppWindow) {
     config.video.widescreen = app.get_widescreen();
     config.video.vsync = app.get_vsync();
     config.video.crt = app.get_apply_crt_shader();
+    config.video.theme = app.get_theme();
     config.emulation.overclock = app.get_overclock_n64_cpu();
     config.emulation.disable_expansion_pak = app.get_disable_expansion_pak();
     config.emulation.usb = app.get_emulate_usb();

--- a/src/ui/gui/appwindow.slint
+++ b/src/ui/gui/appwindow.slint
@@ -65,6 +65,7 @@ export component AppWindow inherits Window {
     out property ra_not_logged_in <=> RAData.not_logged_in;
     in-out property integer_scaling <=> SettingsData.integer_scaling;
     in-out property ssaa <=> SettingsData.ssaa;
+    in-out property theme <=> SettingsData.theme;
     in-out property fullscreen <=> SettingsData.fullscreen;
     in-out property widescreen <=> SettingsData.widescreen;
     in-out property vsync <=> SettingsData.vsync;
@@ -131,6 +132,21 @@ export component AppWindow inherits Window {
     private property <length> safe-bottom: root.safe-area-insets.bottom;
     private property <length> safe-width: root.width - root.safe-left - root.safe-right;
     private property <length> safe-height: root.height - root.safe-top - root.safe-bottom;
+    function apply_theme() {
+        if (root.theme == 1) {
+            Palette.color-scheme = ColorScheme.dark;
+        } else if (root.theme == 2) {
+            Palette.color-scheme = ColorScheme.light;
+        } else {
+            Palette.color-scheme = ColorScheme.unknown;
+        }
+    }
+    init => {
+        apply_theme();
+    }
+    changed theme => {
+        apply_theme();
+    }
 
     min-width: 320px;
     min-height: 240px;

--- a/src/ui/gui/settings_page.slint
+++ b/src/ui/gui/settings_page.slint
@@ -14,6 +14,7 @@ export global SettingsData {
     in-out property <bool> overclock_n64_cpu;
     in-out property <bool> disable_expansion_pak;
     in-out property <int> resolution;
+    in-out property <int> theme;
     in-out property <bool> emulate_usb;
     in-out property <bool> rewind;
     in-out property <bool> emulate_vru;
@@ -41,6 +42,22 @@ export component Settings inherits Page {
                         current-index: SettingsData.resolution;
                         selected => {
                             SettingsData.resolution = self.current-index;
+                        }
+                    }
+                }
+
+                HorizontalBox {
+                    alignment: start;
+                    Text {
+                        text: @tr("Theme:");
+                        vertical-alignment: center;
+                    }
+
+                    ComboBox {
+                        model: [@tr("System"), @tr("Dark"), @tr("Light")];
+                        current-index: SettingsData.theme;
+                        selected => {
+                            SettingsData.theme = self.current-index;
                         }
                     }
                 }

--- a/src/ui/gui/settings_page.slint
+++ b/src/ui/gui/settings_page.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-import { ComboBox, HorizontalBox, VerticalBox, Switch } from "std-widgets.slint";
+import { GridBox, ComboBox, HorizontalBox, VerticalBox, Switch } from "std-widgets.slint";
 import { Page } from "page.slint";
 
 export global SettingsData {
@@ -30,35 +30,34 @@ export component Settings inherits Page {
             alignment: center;
             VerticalBox {
                 alignment: start;
-                HorizontalBox {
-                    alignment: start;
-                    Text {
-                        text: @tr("Resolution:");
-                        vertical-alignment: center;
-                    }
-
-                    ComboBox {
-                        model: ["1x", "2x", "4x", "8x"];
-                        current-index: SettingsData.resolution;
-                        selected => {
-                            SettingsData.resolution = self.current-index;
+                GridBox {
+                    Row {
+                        Text {
+                            text: @tr("Resolution:");
+                            vertical-alignment: center;
                         }
-                    }
-                }
-
-                HorizontalBox {
-                    alignment: start;
-                    Text {
-                        text: @tr("Theme:");
-                        vertical-alignment: center;
-                    }
-
-                    ComboBox {
-                        model: [@tr("System"), @tr("Dark"), @tr("Light")];
-                        current-index: SettingsData.theme;
-                        selected => {
-                            SettingsData.theme = self.current-index;
+                        ComboBox {
+                            model: ["1x", "2x", "4x", "8x"];
+                            current-index: SettingsData.resolution;
+                            selected => {
+                                SettingsData.resolution = self.current-index;
+                            }
                         }
+                        Rectangle {}
+                    }
+                    Row {
+                        Text {
+                            text: @tr("Theme:");
+                            vertical-alignment: center;
+                        }
+                        ComboBox {
+                            model: [@tr("System"), @tr("Dark"), @tr("Light")];
+                            current-index: SettingsData.theme;
+                            selected => {
+                                SettingsData.theme = self.current-index;
+                            }
+                        }
+                        Rectangle {}
                     }
                 }
 


### PR DESCRIPTION
## Summary

Split-out PR from #1128 (one feature per PR). Adds a **theme selector** to Settings: System / Dark / Light.

- `config.video.theme: i32` (0=System, 1=Dark, 2=Light), `#[serde(default)]` so existing config files load cleanly as `0`.
- A ComboBox in Settings; at startup and on change, the AppWindow sets `Palette.color-scheme` — `0`/System follows the OS, so it's **additive: no behavior change** for existing users; Dark/Light explicitly override.
- Resolution + Theme dropdowns are aligned in a shared `GridBox` (per your review).

## Dependencies
None added.

## Testing
- `cargo clippy --features gui -- -Dwarnings` and `cargo clippy --no-default-features -- -Dwarnings` — pass
- `cargo fmt --check` — pass
- Rendered Dark and Light headlessly (software renderer) to confirm `Palette.color-scheme` switches across the UI.

## Translations
Adds "Theme:" / "System" / "Dark" / "Light", translated into all 7 languages (first pass, matching #1129's terminology — happy to adjust if you'd prefer different wording).
