### PR TITLE
Add cli flag for widescreen

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ pub fn run(args: Args, arg_count: usize) -> std::io::Result<()> {
         if args.widescreen {
             device.ui.video.widescreen = true;
         } else {
-            device.ui.video.widescreen = device.ui.config.video.widescreen; 
+            device.ui.video.widescreen = device.ui.config.video.widescreen;
         }
 
         let overclock = args

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub struct Args {
     #[arg(short, long)]
     pub fullscreen: bool,
     #[arg(long)]
+    pub widescreen: bool,
+    #[arg(long)]
     pub overclock: Option<bool>,
     #[arg(long)]
     pub disable_expansion_pak: Option<bool>,
@@ -170,6 +172,13 @@ pub fn run(args: Args, arg_count: usize) -> std::io::Result<()> {
         } else {
             device.ui.video.fullscreen = device.ui.config.video.fullscreen;
         }
+
+        if args.widescreen {
+            device.ui.video.widescreen = true;
+        } else{
+            device.ui.video.widescreen = device.ui.config.video.widescreen; 
+        }
+        
         let overclock = args
             .overclock
             .unwrap_or(device.ui.config.emulation.overclock);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,10 +175,10 @@ pub fn run(args: Args, arg_count: usize) -> std::io::Result<()> {
 
         if args.widescreen {
             device.ui.video.widescreen = true;
-        } else{
+        } else {
             device.ui.video.widescreen = device.ui.config.video.widescreen; 
         }
-        
+
         let overclock = args
             .overclock
             .unwrap_or(device.ui.config.emulation.overclock);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -68,6 +68,7 @@ pub struct Storage {
 pub struct Video {
     pub window: *mut sdl3_sys::video::SDL_Window,
     pub fullscreen: bool,
+    pub widescreen: bool,
     pub fps_tx: Option<tokio::sync::mpsc::UnboundedSender<bool>>,
     pub fps_rx: Option<tokio::sync::mpsc::UnboundedReceiver<bool>>,
     pub vis_tx: Option<tokio::sync::mpsc::UnboundedSender<bool>>,
@@ -267,6 +268,7 @@ impl Ui {
             video: Video {
                 window: std::ptr::null_mut(),
                 fullscreen: false,
+                widescreen: false,
                 fps_tx: Some(fps_tx),
                 fps_rx: Some(fps_rx),
                 vis_tx: Some(vis_tx),

--- a/src/ui/video.rs
+++ b/src/ui/video.rs
@@ -20,8 +20,8 @@ fn build_gfx_info(device: &mut device::Device, netplay: bool) -> GFX_INFO {
         DPC_END_REG: &mut device.rdp.regs_dpc[device::rdp::DPC_END_REG],
         DPC_STATUS_REG: &mut device.rdp.regs_dpc[device::rdp::DPC_STATUS_REG],
         PAL: device.cart.pal,
-        widescreen: device.ui.config.video.widescreen,
         fullscreen: device.ui.video.fullscreen,
+        widescreen: device.ui.video.widescreen,
         vsync: if !netplay {
             device.ui.config.video.vsync
         } else {
@@ -56,14 +56,14 @@ pub fn init(device: &mut device::Device, netplay: bool) {
         2
     };
     if device.cart.pal {
-        window_width = if device.ui.config.video.widescreen {
+        window_width = if device.ui.video.widescreen {
             PAL_WIDESCREEN_WIDTH * scale
         } else {
             PAL_STANDARD_WIDTH * scale
         };
         window_height = PAL_HEIGHT * scale;
     } else {
-        window_width = if device.ui.config.video.widescreen {
+        window_width = if device.ui.video.widescreen {
             NTSC_WIDESCREEN_WIDTH * scale
         } else {
             NTSC_STANDARD_WIDTH * scale


### PR DESCRIPTION
### Summary
Added a widescreen flag to the cli, particularly useful for people who use third party launchers and want to use widescreen on a per-game basis. It is functionally identical to the fullscreen flag in that it falls back to the user set configuration when it's not passed in.
### Testing
Testing performed on Windows 11 25H2
Ran `.\gopher64.exe "rom.z64"` in Powershell with and without widescreen enabled in the config, both returned expected behavior (respected configuration)
Ran `.\gopher64.exe "rom.z64" --widescreen` in Powershell with and without widescreen enabled in the config, both returned expected behavior (always widescreen)
`--widescreen` flag did not affect the user set configuration when launched without it
### Dependencies
`None`
### Notes
I contemplated using the [`SDL_SetWindowAspectRatio`](https://wiki.libsdl.org/SDL3/SDL_SetWindowAspectRatio) boolean but decided against it as the if statements for `device.cart.pal` and `device.cart.ntsc` in `video.rs` seem to handle the aspect ratio themselves and I didn't want to interfere with them.