### PR TITLE
Add GameCube controller support via Wii U adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,6 +2790,7 @@ dependencies = [
  "jni 0.22.4",
  "matchbox_socket",
  "mimalloc",
+ "nusb",
  "open",
  "postcard",
  "quick-xml 0.41.0",
@@ -3807,6 +3808,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-kit-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d3a048d09fbb6597dbf7c69f40d14df4a49487db1487191618c893fc3b1c26"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4223,6 +4234,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
 dependencies = [
  "sha2 0.11.0",
+]
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4667,6 +4687,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "nusb"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "215a49c10e8cff30a0da93b258b21846c4e9242f7683748cfa8474fdc2e4d22b"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "futures-core",
+ "io-kit-sys",
+ "linux-raw-sys 0.12.1",
+ "log",
+ "once_cell",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ dirs = "6.0"
 open = { version = "5.3", optional = true }
 sdl3-sys = { version = "0.6", features = ["build-from-source-static"] }
 sdl3-ttf-sys = { version = "0.6", features = ["build-static-vendored", "no-sdlttf-harfbuzz", "no-sdlttf-plutosvg"] }
+nusb = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
 slint = { version = "1.16", default-features = false, features = ["compat-1-2", "std", "backend-android-activity-06", "accessibility"], optional = true }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ https://github.com/gopher64/gopher64/wiki
 
 Keys are mapped according to [these defaults](https://github.com/gopher64/gopher64/wiki/Default-Keyboard-Setup). Xbox-style controllers also have a [default mapping applied](https://github.com/gopher64/gopher64/wiki/Default-Gamepad-Setup).
 
+## GameCube controller (Wii U USB adapter)
+
+Gopher64 can read GameCube controllers through the Nintendo Wii U / Switch USB GameCube adapter (and compatible clones that enumerate as VID `057E` PID `0337`), the same hardware Dolphin uses.
+
+Setup:
+* **Windows:** install the WinUSB driver with [Zadig](https://zadig.akeo.ie/). Select the adapter (`057E:0337`) and install **WinUSB** specifically (not libusbK or libusb-win32). The adapter ports only appear in the controller configuration once this driver is installed.
+* **Linux:** grant access with a udev rule, e.g. put `SUBSYSTEM=="usb", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="0337", MODE="0666"` in `/etc/udev/rules.d/51-gcadapter.rules`, then `sudo udevadm control --reload-rules && sudo udevadm trigger`.
+* **macOS:** no driver needed.
+
+Usage:
+* In the controller configuration, assign one of the "GameCube Adapter Port 1-4" entries to an N64 port and enable that port.
+* The mapping is fixed: A→A, B→B, Start→Start, D-pad→D-pad, GameCube L trigger→N64 Z, R trigger→N64 R, Z→N64 L, C-stick→C-buttons, main stick→N64 stick. The bound input profile contributes only its deadzone.
+* GameCube **X** is the hotkey modifier (like the gamepad Back button): hold it with another button for save/load state and other shortcuts. Hold **X + B** to cycle the controller pak; switch to the Rumble Pak this way to feel rumble (the default pak does not rumble).
+* Rumble on the official adapter requires its second (black) USB plug to be connected to a powered port; wireless WaveBird controllers never rumble.
+
 ## netplay
 
 Gopher64 supports P2P netplay (online play with others).

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,6 +4,7 @@ pub mod audio;
 #[cfg(feature = "gui")]
 pub mod cheats;
 pub mod config;
+pub mod gca;
 #[cfg(feature = "gui")]
 pub mod gui;
 pub mod input;
@@ -51,6 +52,9 @@ unsafe impl Sync for Audio {}
 pub struct Input {
     pub keyboard_state: *const bool,
     pub controllers: [input::Controllers; 4],
+    // Lazily started when a channel is assigned to an adapter port; owns the USB
+    // reader thread. `None` until then, and on Android (no-op stub).
+    pub gca: Option<gca::Adapter>,
 }
 
 unsafe impl Send for Input {}
@@ -193,6 +197,7 @@ impl Ui {
                         rumble: false,
                         guid: sdl3_sys::guid::SDL_GUID::default(),
                         last_key_state: 0,
+                        gca_port: None,
                     },
                     input::Controllers {
                         game_controller: std::ptr::null_mut(),
@@ -200,6 +205,7 @@ impl Ui {
                         rumble: false,
                         guid: sdl3_sys::guid::SDL_GUID::default(),
                         last_key_state: 0,
+                        gca_port: None,
                     },
                     input::Controllers {
                         game_controller: std::ptr::null_mut(),
@@ -207,6 +213,7 @@ impl Ui {
                         rumble: false,
                         guid: sdl3_sys::guid::SDL_GUID::default(),
                         last_key_state: 0,
+                        gca_port: None,
                     },
                     input::Controllers {
                         game_controller: std::ptr::null_mut(),
@@ -214,9 +221,11 @@ impl Ui {
                         rumble: false,
                         guid: sdl3_sys::guid::SDL_GUID::default(),
                         last_key_state: 0,
+                        gca_port: None,
                     },
                 ],
                 keyboard_state: std::ptr::null_mut(),
+                gca: None,
             },
             storage: Storage {
                 save_state_slot: 0,

--- a/src/ui/gca/mod.rs
+++ b/src/ui/gca/mod.rs
@@ -1,0 +1,328 @@
+//! GameCube controller support via the Nintendo Wii U USB adapter.
+//!
+//! [`protocol`] holds the pure parsing, calibration, and decoding logic. This
+//! module owns the USB transport: a background thread that opens the adapter,
+//! streams input reports into a shared snapshot, and writes rumble.
+//!
+//! The transport is nusb-backed and desktop-only; Android keeps the no-op stub
+//! below so the rest of the UI compiles unconditionally without scattering `cfg`
+//! through the input pipeline. The public surface is the same on every target:
+//! [`adapter_present`] and [`Adapter`].
+
+pub mod protocol;
+
+pub use protocol::{GcCalibration, GcPortState};
+
+#[cfg(not(target_os = "android"))]
+pub use desktop::{Adapter, adapter_present};
+
+#[cfg(target_os = "android")]
+pub use stub::{Adapter, adapter_present};
+
+#[cfg(target_os = "android")]
+mod stub {
+    use super::{GcCalibration, GcPortState};
+
+    pub fn adapter_present() -> bool {
+        false
+    }
+
+    #[derive(Default)]
+    pub struct Adapter {}
+
+    impl Adapter {
+        pub fn start() -> Adapter {
+            Adapter::default()
+        }
+        pub fn port_state(&self, _port: usize) -> (GcPortState, GcCalibration) {
+            (GcPortState::default(), GcCalibration::default())
+        }
+        pub fn set_rumble(&self, _port: usize, _on: bool) {}
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+mod desktop {
+    use super::protocol::{self, GcCalibration, GcPortState};
+    use nusb::descriptors::TransferType;
+    use nusb::transfer::TransferError;
+    use nusb::transfer::{ControlOut, ControlType, Direction, In, Interrupt, Out, Recipient};
+    use nusb::{DeviceInfo, Endpoint, Interface, MaybeFuture};
+    use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::thread::JoinHandle;
+    use std::time::Duration;
+
+    const VID: u16 = 0x057e;
+    const PID: u16 = 0x0337;
+    const INTERFACE: u8 = 0;
+    const INIT_BYTE: u8 = 0x13;
+    const RUMBLE_CMD: u8 = 0x11;
+    // Class control request some third-party adapters (Nyko) need before they
+    // start streaming; the official adapter and Mayflash reject it (ignored).
+    const NYKO_INIT_REQUEST: u8 = 11;
+    const NYKO_INIT_VALUE: u16 = 0x0001;
+    // Endpoint addresses used if descriptor discovery somehow finds nothing.
+    const FALLBACK_IN: u8 = 0x81;
+    const FALLBACK_OUT: u8 = 0x02;
+
+    const READ_TIMEOUT: Duration = Duration::from_millis(16);
+    const WRITE_TIMEOUT: Duration = Duration::from_millis(100);
+    const CONTROL_TIMEOUT: Duration = Duration::from_millis(1000);
+    const RECONNECT_DELAY: Duration = Duration::from_millis(500);
+    // Keep a few reads in flight so the host controller always has work pending.
+    const PENDING_READS: usize = 4;
+    const PORTS: usize = 4;
+
+    type Shared = Arc<Mutex<([GcPortState; PORTS], [GcCalibration; PORTS])>>;
+    type EpIn = Endpoint<Interrupt, In>;
+    type EpOut = Endpoint<Interrupt, Out>;
+
+    /// Owns the background USB reader thread and the shared per-port snapshot.
+    /// The single owner lives in [`crate::ui::Input`]; dropping it stops and
+    /// joins the thread.
+    pub struct Adapter {
+        shared: Shared,
+        rumble: Arc<[AtomicU8; PORTS]>,
+        stop: Arc<AtomicBool>,
+        thread: Option<JoinHandle<()>>,
+    }
+
+    impl Adapter {
+        /// Start the reader thread. Returns even when no adapter is present yet;
+        /// the thread retries connecting, giving basic hotplug support.
+        pub fn start() -> Adapter {
+            let shared: Shared = Arc::new(Mutex::new((
+                [GcPortState::default(); PORTS],
+                [GcCalibration::default(); PORTS],
+            )));
+            let rumble = Arc::new([
+                AtomicU8::new(0),
+                AtomicU8::new(0),
+                AtomicU8::new(0),
+                AtomicU8::new(0),
+            ]);
+            let stop = Arc::new(AtomicBool::new(false));
+
+            let thread = {
+                let shared = shared.clone();
+                let rumble = rumble.clone();
+                let stop = stop.clone();
+                std::thread::spawn(move || run(&shared, &rumble, &stop))
+            };
+
+            Adapter {
+                shared,
+                rumble,
+                stop,
+                thread: Some(thread),
+            }
+        }
+
+        /// Latest snapshot and calibration for an adapter port (`0..=3`).
+        pub fn port_state(&self, port: usize) -> (GcPortState, GcCalibration) {
+            debug_assert!(port < PORTS);
+            // Recover from a poisoned lock: a panic in the USB thread must never
+            // take down the emulation thread, and the bytes are still valid.
+            let guard = self.shared.lock().unwrap_or_else(|e| e.into_inner());
+            (guard.0[port], guard.1[port])
+        }
+
+        /// Set the rumble motor on or off for an adapter port (`0..=3`).
+        pub fn set_rumble(&self, port: usize, on: bool) {
+            debug_assert!(port < PORTS);
+            self.rumble[port].store(on as u8, Ordering::Relaxed);
+        }
+    }
+
+    impl Drop for Adapter {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::Relaxed);
+            if let Some(thread) = self.thread.take() {
+                let _ = thread.join();
+            }
+        }
+    }
+
+    /// True when a usable adapter is connected. On Windows this additionally
+    /// requires the WinUSB driver to be bound, so ports are only offered once
+    /// they can actually be opened.
+    pub fn adapter_present() -> bool {
+        nusb::list_devices()
+            .wait()
+            .map(|mut devices| devices.any(|d| is_adapter(&d)))
+            .unwrap_or(false)
+    }
+
+    fn is_adapter(info: &DeviceInfo) -> bool {
+        if info.vendor_id() != VID || info.product_id() != PID {
+            return false;
+        }
+        // nusb enumerates every USB device on Windows regardless of driver, but
+        // only a WinUSB-bound device can be opened; require it so the config UI
+        // never offers ports that would fail to open.
+        #[cfg(target_os = "windows")]
+        {
+            info.driver()
+                .is_some_and(|d| d.eq_ignore_ascii_case("winusb"))
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            true
+        }
+    }
+
+    fn run(shared: &Shared, rumble: &Arc<[AtomicU8; PORTS]>, stop: &Arc<AtomicBool>) {
+        let mut announced_failure = false;
+        while !stop.load(Ordering::Relaxed) {
+            match connect() {
+                Some((interface, mut ep_in, mut ep_out)) => {
+                    announced_failure = false;
+                    run_io(&mut ep_in, &mut ep_out, shared, rumble, stop);
+                    // Endpoints/interface keep the device open; drop them and
+                    // reset the snapshot before attempting to reconnect.
+                    drop((ep_in, ep_out, interface));
+                    clear_connection(shared);
+                }
+                None => {
+                    if !announced_failure {
+                        eprintln!(
+                            "GameCube adapter: not available (check it is plugged in and, on \
+                             Windows, that the WinUSB driver is installed with Zadig)"
+                        );
+                        announced_failure = true;
+                    }
+                    std::thread::sleep(RECONNECT_DELAY);
+                }
+            }
+        }
+    }
+
+    fn connect() -> Option<(Interface, EpIn, EpOut)> {
+        let info = nusb::list_devices().wait().ok()?.find(is_adapter)?;
+        let device = info.open().wait().ok()?;
+        // Detaches the kernel driver on Linux; a plain claim elsewhere.
+        let interface = device.detach_and_claim_interface(INTERFACE).wait().ok()?;
+        let (in_addr, out_addr) = endpoints(&interface);
+        let ep_in = interface.endpoint::<Interrupt, In>(in_addr).ok()?;
+        let mut ep_out = interface.endpoint::<Interrupt, Out>(out_addr).ok()?;
+        init(&interface, &mut ep_out);
+        Some((interface, ep_in, ep_out))
+    }
+
+    fn endpoints(interface: &Interface) -> (u8, u8) {
+        let mut in_addr = None;
+        let mut out_addr = None;
+        if let Some(desc) = interface.descriptor() {
+            for ep in desc.endpoints() {
+                if ep.transfer_type() != TransferType::Interrupt {
+                    continue;
+                }
+                match ep.direction() {
+                    Direction::In => in_addr = Some(ep.address()),
+                    Direction::Out => out_addr = Some(ep.address()),
+                }
+            }
+        }
+        (
+            in_addr.unwrap_or(FALLBACK_IN),
+            out_addr.unwrap_or(FALLBACK_OUT),
+        )
+    }
+
+    fn init(interface: &Interface, ep_out: &mut EpOut) {
+        // Best-effort init some third-party adapters need (Nyko); the official
+        // adapter and Mayflash error here, which we ignore, matching Dolphin.
+        let _ = interface
+            .control_out(
+                ControlOut {
+                    control_type: ControlType::Class,
+                    recipient: Recipient::Interface,
+                    request: NYKO_INIT_REQUEST,
+                    value: NYKO_INIT_VALUE,
+                    index: 0,
+                    data: &[],
+                },
+                CONTROL_TIMEOUT,
+            )
+            .wait();
+        // Required: ask the adapter to start streaming input reports.
+        let _ = ep_out.transfer_blocking(vec![INIT_BYTE].into(), WRITE_TIMEOUT);
+    }
+
+    fn run_io(
+        ep_in: &mut EpIn,
+        ep_out: &mut EpOut,
+        shared: &Shared,
+        rumble: &Arc<[AtomicU8; PORTS]>,
+        stop: &Arc<AtomicBool>,
+    ) {
+        let read_len = ep_in.max_packet_size();
+        while ep_in.pending() < PENDING_READS {
+            let buffer = ep_in.allocate(read_len);
+            ep_in.submit(buffer);
+        }
+
+        let mut last_rumble = [0u8; PORTS];
+        while !stop.load(Ordering::Relaxed) {
+            // `None` means the read timed out with the transfer still pending; we
+            // just loop to re-check the stop flag and service rumble.
+            if let Some(completion) = ep_in.wait_next_complete(READ_TIMEOUT) {
+                match completion.status {
+                    Ok(()) => {
+                        let len = completion.actual_len;
+                        update_state(shared, &completion.buffer[..len]);
+                        ep_in.submit(completion.buffer);
+                    }
+                    Err(TransferError::Cancelled) => ep_in.submit(completion.buffer),
+                    Err(TransferError::Stall) => {
+                        let _ = ep_in.clear_halt().wait();
+                        ep_in.submit(completion.buffer);
+                    }
+                    Err(_) => return, // disconnected or fault: reconnect
+                }
+            }
+            send_rumble(ep_out, rumble, &mut last_rumble);
+        }
+    }
+
+    fn update_state(shared: &Shared, report: &[u8]) {
+        let Some(ports) = protocol::parse_report(report) else {
+            return;
+        };
+        let mut guard = shared.lock().unwrap_or_else(|e| e.into_inner());
+        let (snapshots, calibrations) = &mut *guard;
+        for ((snapshot, calibration), port) in snapshots
+            .iter_mut()
+            .zip(calibrations.iter_mut())
+            .zip(ports.iter())
+        {
+            let was_connected = snapshot.connected;
+            *snapshot = *port;
+            if port.connected && !was_connected {
+                *calibration = protocol::capture_origin(port);
+            }
+        }
+    }
+
+    fn clear_connection(shared: &Shared) {
+        let mut guard = shared.lock().unwrap_or_else(|e| e.into_inner());
+        guard.0 = [GcPortState::default(); PORTS];
+        guard.1 = [GcCalibration::default(); PORTS];
+    }
+
+    fn send_rumble(ep_out: &mut EpOut, rumble: &Arc<[AtomicU8; PORTS]>, last: &mut [u8; PORTS]) {
+        let current = [
+            rumble[0].load(Ordering::Relaxed),
+            rumble[1].load(Ordering::Relaxed),
+            rumble[2].load(Ordering::Relaxed),
+            rumble[3].load(Ordering::Relaxed),
+        ];
+        if current == *last {
+            return;
+        }
+        *last = current;
+        let payload = vec![RUMBLE_CMD, current[0], current[1], current[2], current[3]];
+        let _ = ep_out.transfer_blocking(payload.into(), WRITE_TIMEOUT);
+    }
+}

--- a/src/ui/gca/protocol.rs
+++ b/src/ui/gca/protocol.rs
@@ -1,0 +1,276 @@
+//! Pure GameCube adapter report parsing, stick calibration, and GameCube button
+//! decoding.
+//!
+//! No I/O lives here: every function is deterministic and unit-testable without
+//! hardware. This module knows the adapter's byte layout; the GameCube -> N64
+//! button mapping itself lives in `input.rs`, next to the N64 bit definitions.
+
+const REPORT_LEN: usize = 37;
+const REPORT_HEADER: u8 = 0x21;
+const PORT_STRIDE: usize = 9;
+
+// Controller-type byte: bit 4 set = wired, bit 5 set = wireless, else absent.
+const TYPE_CONNECTED: u8 = 0x10 | 0x20;
+
+// `b1` button bits.
+const B1_A: u8 = 1 << 0;
+const B1_B: u8 = 1 << 1;
+const B1_X: u8 = 1 << 2;
+// GC Y (bit 3) has no N64 equivalent and is intentionally not decoded.
+const B1_LEFT: u8 = 1 << 4;
+const B1_RIGHT: u8 = 1 << 5;
+const B1_DOWN: u8 = 1 << 6;
+const B1_UP: u8 = 1 << 7;
+
+// `b2` button bits (R/L are the analog triggers' digital click).
+const B2_START: u8 = 1 << 0;
+const B2_Z: u8 = 1 << 1;
+const B2_R: u8 = 1 << 2;
+const B2_L: u8 = 1 << 3;
+
+/// GameCube stick travel from center to a cardinal extreme, in raw byte units
+/// (center `0x80`, radius `0x7f`). Used to normalize sticks to `[-1.0, 1.0]`.
+const GC_STICK_RADIUS: f64 = 0x7f as f64;
+
+/// A single adapter port's most recent raw report bytes plus its connection
+/// state. Calibration is applied at map time (see [`gc_stick`]), so this stays a
+/// faithful copy of what the device sent.
+#[derive(Default, Clone, Copy)]
+pub struct GcPortState {
+    pub connected: bool,
+    pub b1: u8,
+    pub b2: u8,
+    pub stick_x: u8,
+    pub stick_y: u8,
+    pub cstick_x: u8,
+    pub cstick_y: u8,
+}
+
+impl GcPortState {
+    pub fn a(&self) -> bool {
+        self.b1 & B1_A != 0
+    }
+    pub fn b(&self) -> bool {
+        self.b1 & B1_B != 0
+    }
+    pub fn x(&self) -> bool {
+        self.b1 & B1_X != 0
+    }
+    pub fn dpad_left(&self) -> bool {
+        self.b1 & B1_LEFT != 0
+    }
+    pub fn dpad_right(&self) -> bool {
+        self.b1 & B1_RIGHT != 0
+    }
+    pub fn dpad_down(&self) -> bool {
+        self.b1 & B1_DOWN != 0
+    }
+    pub fn dpad_up(&self) -> bool {
+        self.b1 & B1_UP != 0
+    }
+    pub fn start(&self) -> bool {
+        self.b2 & B2_START != 0
+    }
+    pub fn z(&self) -> bool {
+        self.b2 & B2_Z != 0
+    }
+    /// Digital click of the analog R trigger.
+    pub fn r(&self) -> bool {
+        self.b2 & B2_R != 0
+    }
+    /// Digital click of the analog L trigger.
+    pub fn l(&self) -> bool {
+        self.b2 & B2_L != 0
+    }
+}
+
+/// Per-port neutral-position calibration, captured the first time a controller
+/// is seen on a port (Dolphin-style origin).
+#[derive(Default, Clone, Copy)]
+pub struct GcCalibration {
+    pub origin_x: u8,
+    pub origin_y: u8,
+    pub origin_cx: u8,
+    pub origin_cy: u8,
+}
+
+/// Parse a 37-byte adapter input report into the four port states. Returns
+/// `None` if the buffer length or header byte is invalid (the boundary check for
+/// the untrusted USB payload).
+pub fn parse_report(report: &[u8]) -> Option<[GcPortState; 4]> {
+    if report.len() != REPORT_LEN || report[0] != REPORT_HEADER {
+        return None;
+    }
+
+    let mut ports = [GcPortState::default(); 4];
+    for (port, state) in ports.iter_mut().enumerate() {
+        let base = 1 + PORT_STRIDE * port;
+        state.connected = report[base] & TYPE_CONNECTED != 0;
+        state.b1 = report[base + 1];
+        state.b2 = report[base + 2];
+        state.stick_x = report[base + 3];
+        state.stick_y = report[base + 4];
+        state.cstick_x = report[base + 5];
+        state.cstick_y = report[base + 6];
+        // Bytes 7-8 are the analog L/R trigger pressures, unused by the N64 mapping.
+    }
+    Some(ports)
+}
+
+/// Capture the neutral origin for a port from a valid report: its current stick
+/// positions become the calibrated center.
+pub fn capture_origin(state: &GcPortState) -> GcCalibration {
+    GcCalibration {
+        origin_x: state.stick_x,
+        origin_y: state.stick_y,
+        origin_cx: state.cstick_x,
+        origin_cy: state.cstick_y,
+    }
+}
+
+fn normalize(value: u8, origin: u8) -> f64 {
+    (value as f64 - origin as f64) / GC_STICK_RADIUS
+}
+
+/// Origin-corrected, radius-scaled main stick as normalized axes in roughly
+/// `[-1.0, 1.0]` (up = positive). The caller scales to the N64 range and applies
+/// the deadzone and bounding.
+pub fn gc_stick(state: &GcPortState, cal: &GcCalibration) -> (f64, f64) {
+    (
+        normalize(state.stick_x, cal.origin_x),
+        normalize(state.stick_y, cal.origin_y),
+    )
+}
+
+/// Origin-corrected, radius-scaled C-stick as normalized axes in roughly
+/// `[-1.0, 1.0]` (up = positive). The caller thresholds these into C-buttons.
+pub fn gc_cstick(state: &GcPortState, cal: &GcCalibration) -> (f64, f64) {
+    (
+        normalize(state.cstick_x, cal.origin_cx),
+        normalize(state.cstick_y, cal.origin_cy),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Build a 37-byte report with one port populated at the given offset bytes.
+    fn report_with_port(port: usize, bytes: [u8; PORT_STRIDE]) -> Vec<u8> {
+        let mut r = vec![0u8; REPORT_LEN];
+        r[0] = REPORT_HEADER;
+        let base = 1 + PORT_STRIDE * port;
+        r[base..base + PORT_STRIDE].copy_from_slice(&bytes);
+        r
+    }
+
+    #[test]
+    fn rejects_bad_length() {
+        assert!(parse_report(&[REPORT_HEADER; 10]).is_none());
+        assert!(parse_report(&[]).is_none());
+    }
+
+    #[test]
+    fn rejects_bad_header() {
+        let mut r = vec![0u8; REPORT_LEN];
+        r[0] = 0x00;
+        assert!(parse_report(&r).is_none());
+    }
+
+    #[test]
+    fn parses_each_port_field() {
+        // Port 2: wired, A+Start pressed, sticks set; trailing trigger bytes ignored.
+        let bytes = [0x10, B1_A, B2_START, 0x90, 0x70, 0xa0, 0x60, 0x11, 0x22];
+        let ports = parse_report(&report_with_port(2, bytes)).unwrap();
+
+        assert!(!ports[0].connected);
+        let p = ports[2];
+        assert!(p.connected);
+        assert!(p.a() && p.start());
+        assert!(!p.b());
+        assert_eq!(p.stick_x, 0x90);
+        assert_eq!(p.stick_y, 0x70);
+        assert_eq!(p.cstick_x, 0xa0);
+        assert_eq!(p.cstick_y, 0x60);
+    }
+
+    #[test]
+    fn decodes_every_button_bit() {
+        let all_b1 = GcPortState {
+            b1: 0xff,
+            ..Default::default()
+        };
+        assert!(
+            all_b1.a()
+                && all_b1.b()
+                && all_b1.x()
+                && all_b1.dpad_left()
+                && all_b1.dpad_right()
+                && all_b1.dpad_down()
+                && all_b1.dpad_up()
+        );
+        let all_b2 = GcPortState {
+            b2: 0xff,
+            ..Default::default()
+        };
+        assert!(all_b2.start() && all_b2.z() && all_b2.r() && all_b2.l());
+    }
+
+    #[test]
+    fn disconnected_when_type_byte_zero() {
+        let bytes = [0x00, B1_A, 0, 0x80, 0x80, 0x80, 0x80, 0, 0];
+        let ports = parse_report(&report_with_port(0, bytes)).unwrap();
+        assert!(!ports[0].connected);
+    }
+
+    #[test]
+    fn stick_centered_at_origin_is_zero() {
+        let state = GcPortState {
+            stick_x: 0x80,
+            stick_y: 0x80,
+            ..Default::default()
+        };
+        let cal = capture_origin(&state);
+        let (x, y) = gc_stick(&state, &cal);
+        assert!(x.abs() < 1e-9 && y.abs() < 1e-9);
+    }
+
+    #[test]
+    fn full_deflection_reaches_unit_magnitude() {
+        let cal = GcCalibration {
+            origin_x: 0x80,
+            origin_y: 0x80,
+            ..Default::default()
+        };
+        // origin + radius (0x80 + 0x7f = 0xff) -> +1.0 exactly.
+        let up_right = GcPortState {
+            stick_x: 0xff,
+            stick_y: 0xff,
+            ..Default::default()
+        };
+        let (x, y) = gc_stick(&up_right, &cal);
+        assert!((x - 1.0).abs() < 1e-9);
+        assert!((y - 1.0).abs() < 1e-9);
+        // Bottom-left clamps slightly past -1.0 (caller bounds it).
+        let down_left = GcPortState {
+            stick_x: 0x00,
+            stick_y: 0x00,
+            ..Default::default()
+        };
+        let (x, y) = gc_stick(&down_left, &cal);
+        assert!(x < -1.0 && y < -1.0);
+    }
+
+    #[test]
+    fn off_center_origin_is_subtracted() {
+        // A pad whose neutral rests at 0x88 should read zero there, not at 0x80.
+        let neutral = GcPortState {
+            stick_x: 0x88,
+            stick_y: 0x78,
+            ..Default::default()
+        };
+        let cal = capture_origin(&neutral);
+        let (x, y) = gc_stick(&neutral, &cal);
+        assert!(x.abs() < 1e-9 && y.abs() < 1e-9);
+    }
+}

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -7,7 +7,15 @@ const Y_AXIS_SHIFT: usize = 24;
 
 const MAX_AXIS_VALUE: f64 = 85.0;
 
+// Fraction of full C-stick travel past which a C-button registers.
+const GC_CSTICK_THRESHOLD: f64 = 0.5;
+
 pub const UNKNOWN_CONTROLLER_NAME: &str = "Unknown controller";
+
+// Sentinel device "path" stored in `controller_assignment` for an adapter port,
+// e.g. "gca:0".."gca:3". Distinguishes adapter pseudo-devices from SDL paths.
+pub const GCA_PATH_PREFIX: &str = "gca:";
+pub const GCA_PORT_COUNT: usize = 4;
 
 #[derive(Default)]
 pub struct Controllers {
@@ -16,6 +24,9 @@ pub struct Controllers {
     pub joystick: *mut sdl3_sys::joystick::SDL_Joystick,
     pub guid: sdl3_sys::guid::SDL_GUID,
     pub last_key_state: u32,
+    // `Some(port)` when this channel reads from adapter port `port` instead of
+    // an SDL device. Set by `init()` from a `gca:` controller assignment.
+    pub gca_port: Option<usize>,
 }
 
 #[derive(Default, PartialEq, Copy, Clone, serde::Serialize, serde::Deserialize)]
@@ -218,6 +229,12 @@ pub fn set_rumble(ui: &ui::Ui, channel: usize, rumble: u8) {
     if !ui.input.controllers[channel].rumble {
         return;
     }
+    if let Some(port) = ui.input.controllers[channel].gca_port {
+        if let Some(adapter) = &ui.input.gca {
+            adapter.set_rumble(port, rumble & 1 != 0);
+        }
+        return;
+    }
     let controller = ui.input.controllers[channel].game_controller;
     let joystick = ui.input.controllers[channel].joystick;
     if !controller.is_null() {
@@ -260,7 +277,13 @@ pub fn get_controller_names() -> Vec<String> {
 
     #[cfg(not(target_os = "android"))]
     {
-        let mut controllers: Vec<String> = vec![];
+        let mut controllers: Vec<String> = vec!["None".to_string()];
+
+        if ui::gca::adapter_present() {
+            for port in 1..=GCA_PORT_COUNT {
+                controllers.push(format!("GameCube Adapter Port {port}"));
+            }
+        }
 
         for joystick in get_joysticks().iter() {
             let name = unsafe { sdl3_sys::joystick::SDL_GetJoystickNameForID(*joystick) };
@@ -270,7 +293,6 @@ pub fn get_controller_names() -> Vec<String> {
                 unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() }.to_string()
             });
         }
-        controllers.insert(0, "None".into());
 
         controllers
     }
@@ -283,7 +305,13 @@ pub fn get_controller_paths() -> Vec<String> {
 
     #[cfg(not(target_os = "android"))]
     {
-        let mut controller_paths: Vec<String> = vec![];
+        let mut controller_paths: Vec<String> = vec![String::new()];
+
+        if ui::gca::adapter_present() {
+            for port in 0..GCA_PORT_COUNT {
+                controller_paths.push(format!("{GCA_PATH_PREFIX}{port}"));
+            }
+        }
 
         for joystick in get_joysticks().iter() {
             let path = unsafe { sdl3_sys::joystick::SDL_GetJoystickPathForID(*joystick) };
@@ -293,7 +321,6 @@ pub fn get_controller_paths() -> Vec<String> {
                 unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() }.to_string()
             });
         }
-        controller_paths.insert(0, String::new());
 
         controller_paths
     }
@@ -304,6 +331,10 @@ fn handle_joystick_events(ui: &mut ui::Ui) {
     if joystick_event.joystick_id != 0 {
         let joystick_id = sdl3_sys::joystick::SDL_JoystickID(joystick_event.joystick_id);
         for (i, controller) in ui.input.controllers.iter_mut().enumerate() {
+            if controller.gca_port.is_some() {
+                // Adapter-backed channels do not use SDL devices.
+                continue;
+            }
             if joystick_event.connected {
                 if let Some(profile) = ui
                     .config
@@ -420,8 +451,122 @@ fn handle_hotkeys(keys: u32, last_key_state: u32) {
     }
 }
 
+// Pack the rounded stick axes into the N64 key bitfield. The `as i8 as u8`
+// round-trip reinterprets the signed value as a two's-complement byte.
+fn pack_axes(keys: &mut u32, x: f64, y: f64) {
+    *keys |= (x.round() as i8 as u8 as u32) << X_AXIS_SHIFT;
+    *keys |= (y.round() as i8 as u8 as u32) << Y_AXIS_SHIFT;
+}
+
+// Map a GameCube adapter port's state to the N64 button/axis bitfield, reusing
+// the same deadzone/bounding pipeline as the SDL path.
+fn gc_keys(state: &ui::gca::GcPortState, cal: &ui::gca::GcCalibration, deadzone: i32) -> u32 {
+    if !state.connected {
+        return 0;
+    }
+    let mut keys: u32 = 0;
+    if state.a() {
+        keys |= 1 << ui::input_profile::A_BUTTON;
+    }
+    if state.b() {
+        keys |= 1 << ui::input_profile::B_BUTTON;
+    }
+    if state.start() {
+        keys |= 1 << ui::input_profile::START_BUTTON;
+    }
+    if state.l() {
+        keys |= 1 << ui::input_profile::Z_TRIG; // GC L click -> N64 Z
+    }
+    if state.r() {
+        keys |= 1 << ui::input_profile::R_TRIG; // GC R click -> N64 R
+    }
+    if state.z() {
+        keys |= 1 << ui::input_profile::L_TRIG; // GC Z -> N64 L
+    }
+    if state.dpad_up() {
+        keys |= 1 << ui::input_profile::U_DPAD;
+    }
+    if state.dpad_down() {
+        keys |= 1 << ui::input_profile::D_DPAD;
+    }
+    if state.dpad_left() {
+        keys |= 1 << ui::input_profile::L_DPAD;
+    }
+    if state.dpad_right() {
+        keys |= 1 << ui::input_profile::R_DPAD;
+    }
+
+    let (cstick_x, cstick_y) = ui::gca::protocol::gc_cstick(state, cal);
+    if cstick_x > GC_CSTICK_THRESHOLD {
+        keys |= 1 << ui::input_profile::R_CBUTTON;
+    }
+    if cstick_x < -GC_CSTICK_THRESHOLD {
+        keys |= 1 << ui::input_profile::L_CBUTTON;
+    }
+    if cstick_y > GC_CSTICK_THRESHOLD {
+        keys |= 1 << ui::input_profile::U_CBUTTON;
+    }
+    if cstick_y < -GC_CSTICK_THRESHOLD {
+        keys |= 1 << ui::input_profile::D_CBUTTON;
+    }
+
+    let (mut x, mut y) = ui::gca::protocol::gc_stick(state, cal);
+    x *= MAX_AXIS_VALUE;
+    y *= MAX_AXIS_VALUE;
+    apply_deadzone(&mut x, &mut y, deadzone);
+    bound_axis(&mut x, &mut y);
+    pack_axes(&mut keys, x, y);
+    keys
+}
+
+// Read a GameCube adapter port and produce N64 input, mirroring the SDL path's
+// hotkey handling (GC X is the hotkey activator).
+fn gca_input(ui: &mut ui::Ui, channel: usize, port: usize) -> InputData {
+    let deadzone = ui
+        .config
+        .input
+        .input_profiles
+        .get(&ui.config.input.input_profile_binding[channel])
+        .map_or(ui::input_profile::DEADZONE_DEFAULT, |profile| {
+            profile.deadzone
+        });
+
+    // Copy the snapshot out so the immutable borrow of `ui.input.gca` is released
+    // before we mutate `ui.input.controllers`.
+    let (state, cal) = match &ui.input.gca {
+        Some(adapter) => adapter.port_state(port),
+        None => {
+            return InputData {
+                data: 0,
+                pak_change_pressed: false,
+            };
+        }
+    };
+
+    let keys = gc_keys(&state, &cal, deadzone);
+    let last_key_state = ui.input.controllers[channel].last_key_state;
+    ui.input.controllers[channel].last_key_state = keys;
+
+    if state.x() {
+        handle_hotkeys(keys, last_key_state);
+        InputData {
+            data: 0,
+            pak_change_pressed: keys & (1 << ui::input_profile::B_BUTTON) != 0,
+        }
+    } else {
+        InputData {
+            data: keys,
+            pak_change_pressed: false,
+        }
+    }
+}
+
 pub fn get(ui: &mut ui::Ui, channel: usize) -> InputData {
     handle_joystick_events(ui);
+
+    if let Some(port) = ui.input.controllers[channel].gca_port {
+        return gca_input(ui, channel, port);
+    }
 
     let profile_name = &ui.config.input.input_profile_binding[channel];
     let Some(profile) = ui.config.input.input_profiles.get(profile_name) else {
@@ -456,8 +601,7 @@ pub fn get(ui: &mut ui::Ui, channel: usize) -> InputData {
     let (mut x, mut y) = set_axis(profile, joystick, controller, ui.input.keyboard_state);
     bound_axis(&mut x, &mut y);
 
-    keys |= (x.round() as i8 as u8 as u32) << X_AXIS_SHIFT;
-    keys |= (y.round() as i8 as u8 as u32) << Y_AXIS_SHIFT;
+    pack_axes(&mut keys, x, y);
 
     let last_key_state = ui.input.controllers[channel].last_key_state;
     ui.input.controllers[channel].last_key_state = keys;
@@ -485,12 +629,28 @@ pub fn get(ui: &mut ui::Ui, channel: usize) -> InputData {
 }
 
 pub fn assign_controller(config: &mut ui::config::Config, controller: i32, port: usize) {
-    let joysticks = get_joysticks();
     if controller < 0 {
         config.input.controller_assignment[port - 1] = None;
-    } else if controller < joysticks.len() as i32 {
-        let path =
-            unsafe { sdl3_sys::joystick::SDL_GetJoystickPathForID(joysticks[controller as usize]) };
+        return;
+    }
+
+    // Order must match get_controller_names(): None, adapter ports (when an
+    // adapter is present), then SDL joysticks.
+    let adapter_count = if ui::gca::adapter_present() {
+        GCA_PORT_COUNT as i32
+    } else {
+        0
+    };
+    if controller < adapter_count {
+        config.input.controller_assignment[port - 1] =
+            Some(format!("{GCA_PATH_PREFIX}{controller}"));
+        return;
+    }
+
+    let joysticks = get_joysticks();
+    let sdl_index = (controller - adapter_count) as usize;
+    if sdl_index < joysticks.len() {
+        let path = unsafe { sdl3_sys::joystick::SDL_GetJoystickPathForID(joysticks[sdl_index]) };
         if !path.is_null() {
             config.input.controller_assignment[port - 1] =
                 Some(unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap().to_string() });
@@ -545,6 +705,19 @@ pub fn init(ui: &mut ui::Ui) {
         if let Some(controller_assignment) = &ui.config.input.controller_assignment[i]
             && ui.config.input.controller_enabled[i]
         {
+            if let Some(port) = controller_assignment
+                .strip_prefix(GCA_PATH_PREFIX)
+                .and_then(|index| index.parse::<usize>().ok())
+                && port < GCA_PORT_COUNT
+            {
+                if ui.input.gca.is_none() {
+                    ui.input.gca = Some(ui::gca::Adapter::start());
+                }
+                ui.input.controllers[i].gca_port = Some(port);
+                ui.input.controllers[i].rumble = true;
+                continue;
+            }
+
             let mut joystick_id = sdl3_sys::everything::SDL_JoystickID(0);
 
             for joystick in get_joysticks().iter() {
@@ -641,6 +814,7 @@ pub fn init(ui: &mut ui::Ui) {
 }
 
 pub fn close(ui: &mut ui::Ui) {
+    ui.input.gca = None; // stops and joins the adapter reader thread
     for controller in ui.input.controllers.iter_mut() {
         if !controller.joystick.is_null() {
             unsafe { sdl3_sys::joystick::SDL_CloseJoystick(controller.joystick) }
@@ -650,5 +824,97 @@ pub fn close(ui: &mut ui::Ui) {
             unsafe { sdl3_sys::gamepad::SDL_CloseGamepad(controller.game_controller) }
             controller.game_controller = std::ptr::null_mut();
         }
+        controller.gca_port = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::gca::{GcCalibration, GcPortState};
+    use crate::ui::input_profile::{
+        A_BUTTON, B_BUTTON, DEADZONE_DEFAULT, L_TRIG, R_CBUTTON, R_TRIG, U_CBUTTON, U_DPAD, Z_TRIG,
+    };
+
+    // A connected pad with both sticks resting on a 0x80 origin, so calibrated
+    // sticks read zero and only the requested buttons show up in the output.
+    fn centered(b1: u8, b2: u8) -> GcPortState {
+        GcPortState {
+            connected: true,
+            b1,
+            b2,
+            stick_x: 0x80,
+            stick_y: 0x80,
+            cstick_x: 0x80,
+            cstick_y: 0x80,
+        }
+    }
+
+    fn centered_cal() -> GcCalibration {
+        GcCalibration {
+            origin_x: 0x80,
+            origin_y: 0x80,
+            origin_cx: 0x80,
+            origin_cy: 0x80,
+        }
+    }
+
+    #[test]
+    fn disconnected_port_maps_to_nothing() {
+        let keys = gc_keys(
+            &GcPortState::default(),
+            &GcCalibration::default(),
+            DEADZONE_DEFAULT,
+        );
+        assert_eq!(keys, 0);
+    }
+
+    #[test]
+    fn triggers_cross_map_to_n64() {
+        let cal = centered_cal();
+        // GC L click (b2 bit 3) -> N64 Z.
+        assert_eq!(
+            gc_keys(&centered(0, 1 << 3), &cal, DEADZONE_DEFAULT),
+            1 << Z_TRIG
+        );
+        // GC Z (b2 bit 1) -> N64 L.
+        assert_eq!(
+            gc_keys(&centered(0, 1 << 1), &cal, DEADZONE_DEFAULT),
+            1 << L_TRIG
+        );
+        // GC R click (b2 bit 2) -> N64 R.
+        assert_eq!(
+            gc_keys(&centered(0, 1 << 2), &cal, DEADZONE_DEFAULT),
+            1 << R_TRIG
+        );
+    }
+
+    #[test]
+    fn face_and_dpad_pass_through() {
+        let cal = centered_cal();
+        assert_eq!(
+            gc_keys(&centered(1 << 0, 0), &cal, DEADZONE_DEFAULT),
+            1 << A_BUTTON
+        );
+        assert_eq!(
+            gc_keys(&centered(1 << 1, 0), &cal, DEADZONE_DEFAULT),
+            1 << B_BUTTON
+        );
+        assert_eq!(
+            gc_keys(&centered(1 << 7, 0), &cal, DEADZONE_DEFAULT),
+            1 << U_DPAD
+        );
+    }
+
+    #[test]
+    fn cstick_past_threshold_sets_cbuttons() {
+        let cal = centered_cal();
+        let mut right = centered(0, 0);
+        right.cstick_x = 0xff; // (0xff - 0x80) / 0x7f ~= +1.0, past +0.5
+        assert_eq!(gc_keys(&right, &cal, DEADZONE_DEFAULT), 1 << R_CBUTTON);
+
+        let mut up = centered(0, 0);
+        up.cstick_y = 0xff;
+        assert_eq!(gc_keys(&up, &cal, DEADZONE_DEFAULT), 1 << U_CBUTTON);
     }
 }

--- a/src/ui/input_profile.rs
+++ b/src/ui/input_profile.rs
@@ -1,17 +1,17 @@
 use crate::ui;
 
-const R_DPAD: usize = 0;
-const L_DPAD: usize = 1;
-const D_DPAD: usize = 2;
-const U_DPAD: usize = 3;
+pub const R_DPAD: usize = 0;
+pub const L_DPAD: usize = 1;
+pub const D_DPAD: usize = 2;
+pub const U_DPAD: usize = 3;
 pub const START_BUTTON: usize = 4;
 pub const Z_TRIG: usize = 5;
 pub const B_BUTTON: usize = 6;
-const A_BUTTON: usize = 7;
-const R_CBUTTON: usize = 8;
+pub const A_BUTTON: usize = 7;
+pub const R_CBUTTON: usize = 8;
 pub const L_CBUTTON: usize = 9;
-const D_CBUTTON: usize = 10;
-const U_CBUTTON: usize = 11;
+pub const D_CBUTTON: usize = 10;
+pub const U_CBUTTON: usize = 11;
 pub const R_TRIG: usize = 12;
 pub const L_TRIG: usize = 13;
 pub const AXIS_RIGHT: usize = 14;


### PR DESCRIPTION
## What

Adds support for driving N64 controllers with a real GameCube controller through the Nintendo Wii U / Switch USB GameCube adapter (VID `057E` / PID `0337`, the same hardware Dolphin uses).

## Why this approach

SDL3 cannot see the adapter on Windows: it is a vendor-specific USB device (not HID-class), and SDL's Windows HIDAPI backend has no libusb path. So instead of going through SDL, this talks to the adapter directly over USB with the pure-Rust [`nusb`](https://crates.io/crates/nusb) crate, the way Dolphin uses libusb. `nusb` is added as a **desktop-only** dependency (`[target.'cfg(not(target_os = "android"))'.dependencies]`); Android keeps a no-op stub, so the input pipeline compiles unchanged on every target.

## How it works

- A background thread opens the adapter, sends the `0x13` init, streams the 37-byte input reports into a shared per-port snapshot, and writes rumble. Lives in `src/ui/gca/mod.rs` (the USB transport).
- All the pure parsing, calibration, and button decoding lives in `src/ui/gca/protocol.rs` — deterministic and unit-tested, no hardware needed.
- The fixed GameCube→N64 mapping lives in `input.rs` next to the N64 bit definitions, reusing the existing deadzone/bounding pipeline. Mapping: A→A, B→B, Start→Start, D-pad→D-pad, GC L trigger→N64 Z, R trigger→N64 R, Z→N64 L, C-stick→C-buttons, main stick→stick. GC **X** is the hotkey modifier (like the gamepad Back button). The bound input profile contributes only its deadzone.
- The four adapter ports are exposed as pseudo-devices (`gca:0`..`gca:3`), so the existing per-port assignment, save/load, and rumble paths work unchanged. Ports are only listed when an adapter is present (and, on Windows, bound to the WinUSB driver).

User-facing setup (Zadig/WinUSB on Windows, udev on Linux, rumble caveats) is documented in the README.

## Notes for review

- This is desktop-only; Android gets a compile-time no-op stub.
- To keep the GameCube→N64 mapping reusing the existing N64 button-bit constants (rather than duplicating them), a few of the button-index constants in `input_profile.rs` were made `pub`.
- Rebased onto current `main`, which includes the recent `input.rs`/`input_profile.rs` refactor.

## Testing

Local checks all pass (CI does not run tests):
- `cargo fmt --check`
- `cargo clippy -- -Dwarnings` and `cargo clippy --no-default-features -- -Dwarnings`
- `cargo test` — 12 tests pass, including unit tests for the report parser, calibration, and the GameCube→N64 mapping.

Opened as a **draft** — happy to discuss the approach before it's considered for merge.
