### PR TITLE
Updated README with the build instructions for Ubuntu 25.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ flatpak run --filesystem=host:ro io.github.gopher64.gopher64 /path/to/rom.z64
 
 ## building and usage
 
-1. [Install dependencies](https://github.com/gopher64/gopher64#build-dependencies)
+1. [Install dependencies](#build-dependencies)
 2. [Install rust](https://www.rust-lang.org/tools/install)
 3. `git clone --recursive https://github.com/gopher64/gopher64.git`
 4. `cd gopher64`
@@ -91,5 +91,3 @@ Free code signing for the Windows release is provided by [SignPath.io](https://a
 During online netplay sessions, the server logs your IP address and basic session information (game title and session name) for operational purposes. No additional personal data is collected or stored.
 
 If you enable the RetroAchievements feature, some data is sent to their systems. Please see their terms [here](https://retroachievements.org/terms).
-
-

--- a/README.md
+++ b/README.md
@@ -59,12 +59,20 @@ flatpak run --filesystem=host:ro io.github.gopher64.gopher64 /path/to/rom.z64
 
 ## building and usage
 
-1. Linux only: [install the SDL3 dependencies](https://wiki.libsdl.org/SDL3/README-linux#build-dependencies)
+1. [Install dependencies](https://github.com/gopher64/gopher64#build-dependencies)
 2. [Install rust](https://www.rust-lang.org/tools/install)
 3. `git clone --recursive https://github.com/gopher64/gopher64.git`
 4. `cd gopher64`
-5. `cargo build --release`
-6. `./target/release/gopher64 /path/to/rom.z64`
+5. `git submodule update --init --recursive`
+6. `cargo build --release`
+7. `./target/release/gopher64 /path/to/rom.z64`
+
+### build dependencies
+####  Ubuntu 25
+1. [install the SDL3 dependencies](https://wiki.libsdl.org/SDL3/README-linux#build-dependencies)
+2. ```
+    sudo apt install clang llvm
+    ```
 
 ## contributing
 
@@ -83,3 +91,5 @@ Free code signing for the Windows release is provided by [SignPath.io](https://a
 During online netplay sessions, the server logs your IP address and basic session information (game title and session name) for operational purposes. No additional personal data is collected or stored.
 
 If you enable the RetroAchievements feature, some data is sent to their systems. Please see their terms [here](https://retroachievements.org/terms).
+
+

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ flatpak run --filesystem=host:ro io.github.gopher64.gopher64 /path/to/rom.z64
 
 ### build dependencies
 ####  Ubuntu 25
-1. [install the SDL3 dependencies](https://wiki.libsdl.org/SDL3/README-linux#build-dependencies)
+1. [Install the SDL3 dependencies](https://wiki.libsdl.org/SDL3/README-linux#build-dependencies)
 2. ```
     sudo apt install clang llvm
     ```


### PR DESCRIPTION
## Summary

Clarifies the build instructions in the README.

- Adds a **build dependencies** section with the packages needed on Ubuntu 25
  (`clang` and `llvm`, in addition to the SDL3 dependencies)
- Replaces the Linux-only SDL3 link in step 1 with a link to the new section, so
  the dependency step isn't platform-specific in the numbered list
- Adds an explicit `git submodule update --init --recursive` step

## Motivation
I want to support and contribute to this project. 
Building on a fresh Ubuntu 25 install fails without `clang`/`llvm` and submodule init. 